### PR TITLE
fix(docs): publish versioned docs, repair broken site rendering

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 name: Docs
@@ -10,6 +12,7 @@ name: Docs
 permissions:
   contents: write
 
+# mike commits to the gh-pages branch, so two deploys at once would conflict.
 concurrency:
   group: docs-deploy
   cancel-in-progress: false
@@ -19,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -31,5 +36,35 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build and deploy to GitHub Pages
-        run: uv run --locked --group docs mkdocs gh-deploy --force
+      # A published release is the documented version: it gets its own
+      # directory and takes over the `latest` alias, which is what the site
+      # opens by default.
+      #
+      # --alias-type=copy is required: mike's default symlink alias is not
+      # served by GitHub Pages, which would 404 every /latest/... deep link.
+      - name: Deploy release docs
+        if: github.event_name == 'release'
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${TAG#v}"
+          uv run --locked --group docs mike deploy --push --update-aliases \
+            --alias-type=copy --allow-empty "$version" latest
+          uv run --locked --group docs mike set-default --push --allow-empty latest
+
+      # main documents unreleased code, published separately as `dev` so it can
+      # never be mistaken for the released API.
+      - name: Deploy dev docs
+        if: github.event_name != 'release'
+        run: |
+          uv run --locked --group docs mike deploy --push --allow-empty dev
+
+          # The site root is a redirect written by `set-default`. Point it at
+          # `latest` once a release exists, and at `dev` before the first one,
+          # so the root is never a 404.
+          if uv run --locked --group docs mike list latest >/dev/null 2>&1; then
+            default=latest
+          else
+            default=dev
+          fi
+          uv run --locked --group docs mike set-default --push --allow-empty "$default"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,32 @@ All four type checkers must pass with zero errors. Every code block in
 `README.md` is executed and type-checked by `tests/test_readme_blocks.py` —
 if you change the README, its examples must actually run.
 
+## Documentation
+
+The site is built with MkDocs and published to GitHub Pages by CI — never by
+hand. The API reference is generated from the source docstrings by
+mkdocstrings, and `docs/index.md` includes a marked region of `README.md`, so
+there is no second copy of anything to keep in sync.
+
+Versions are managed by [mike](https://github.com/jimporter/mike) and each one
+lives in its own directory on the `gh-pages` branch:
+
+| Version   | Source                | Deployed when                     |
+| --------- | --------------------- | --------------------------------- |
+| `latest`  | the newest release    | a GitHub Release is published     |
+| `<x.y.z>` | that release, pinned  | a GitHub Release is published     |
+| `dev`     | the `main` branch     | every push to `main`              |
+
+`latest` is what the site opens by default; `dev` documents unreleased code.
+Deep links in the README point at `/latest/...` on purpose — they must keep
+working for people running the released version.
+
+```sh
+just docs           # live preview of your working tree
+just docs-build     # strict build, same as CI
+just docs-versions  # preview the published multi-version site
+```
+
 ## Commit messages
 
 Releases are automated with [release-please](https://github.com/googleapis/release-please),

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Rust-like `Result` type for Python 3.11+, fully type annotated.
 
-<div align="center">
+<div align="center" markdown="1">
 
 > *Explicit is better than implicit.*
 > *Errors should never pass silently.*
@@ -18,7 +18,9 @@ A Rust-like `Result` type for Python 3.11+, fully type annotated.
 
 📚 **[Documentation](https://deliro.github.io/corrode/)** — the full API
 reference is generated from the source docstrings, so it always matches the
-code, and every example in it is executed as a doctest in CI.
+code, and every example in it is executed as a doctest in CI. The site is
+versioned: it opens on `latest` (the newest release), every past release stays
+available, and `dev` tracks unreleased `main`. Pick one in the header.
 
 ## Table of Contents
 
@@ -34,6 +36,8 @@ code, and every example in it is executed as a doctest in CI.
 - [Typing](#typing)
 - [Stability](#stability)
 - [License](#license)
+
+<!-- --8<-- [start:body] -->
 
 ## Installation
 
@@ -197,7 +201,7 @@ Use `is_ok()` / `is_err()`, pattern matching, or `is_ok_and()` instead.
 ## Tour
 
 A taste of the combinators. Every sync method has a doctested example in the
-[API reference](https://deliro.github.io/corrode/api/result/); the `_async`
+[API reference](https://deliro.github.io/corrode/latest/api/result/); the `_async`
 variants mirror their sync counterparts:
 
 ```python
@@ -261,7 +265,7 @@ def parse_port(key: str) -> int:
 assert parse_port("PORT") == Ok(8080)  # Result[int, KeyError | ValueError]
 ```
 
-Also available — see the [API reference](https://deliro.github.io/corrode/api/result/):
+Also available — see the [API reference](https://deliro.github.io/corrode/latest/api/result/):
 
 - transforms: `map_err`, `map_or`, `map_or_else`
 - predicates: `is_ok`, `is_err`, `is_ok_and`, `is_err_and`
@@ -276,7 +280,7 @@ Also available — see the [API reference](https://deliro.github.io/corrode/api/
 ## Iterator utilities
 
 `corrode.iterator` works with iterables of `Result` values
-([API reference](https://deliro.github.io/corrode/api/iterator/)):
+([API reference](https://deliro.github.io/corrode/latest/api/iterator/)):
 
 | Function        | Semantics                                                          |
 | --------------- | ------------------------------------------------------------------ |
@@ -315,7 +319,7 @@ assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a numbe
 ## Async iterator utilities
 
 `corrode.async_iterator` runs coroutines or tasks concurrently
-([API reference](https://deliro.github.io/corrode/api/async-iterator/)):
+([API reference](https://deliro.github.io/corrode/latest/api/async-iterator/)):
 
 | Function                                   | Semantics                                                      |
 | ------------------------------------------ | -------------------------------------------------------------- |
@@ -491,6 +495,8 @@ always listed in the [changelog](https://github.com/deliro/corrode/blob/main/CHA
 Versioning follows [SemVer](https://semver.org); after 1.0 the public API —
 everything exported from `corrode`, `corrode.iterator`, and
 `corrode.async_iterator` — will only break with a major release.
+
+<!-- --8<-- [end:body] -->
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ available, and `dev` tracks unreleased `main`. Pick one in the header.
   - [Exceptions and `ExceptionGroup`](#exceptions-and-exceptiongroup)
 - [Adopting corrode in an existing codebase](#adopting-corrode-in-an-existing-codebase)
 - [Typing](#typing)
-- [Stability](#stability)
 - [License](#license)
 
 <!-- --8<-- [start:body] -->
@@ -487,14 +486,6 @@ type information works out of the box, no stubs needed. Every release is
 verified against **four** type checkers in strict mode: mypy, basedpyright,
 ty, and pyrefly. All README examples are executed *and* type-checked in CI;
 all docstring examples run as doctests.
-
-## Stability
-
-`corrode` is pre-1.0: breaking changes may occur in minor releases and are
-always listed in the [changelog](https://github.com/deliro/corrode/blob/main/CHANGELOG.md).
-Versioning follows [SemVer](https://semver.org); after 1.0 the public API —
-everything exported from `corrode`, `corrode.iterator`, and
-`corrode.async_iterator` — will only break with a major release.
 
 <!-- --8<-- [end:body] -->
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,11 @@
---8<-- "README.md"
+# corrode
+
+A Rust-like `Result` type for Python 3.11+, fully type annotated.
+
+!!! info "Which version am I reading?"
+
+    Use the version selector in the header. `latest` tracks the newest
+    release on PyPI; `dev` is the current `main` branch and may document
+    unreleased changes.
+
+--8<-- "README.md:body"

--- a/justfile
+++ b/justfile
@@ -39,8 +39,13 @@ test-cov:
 build:
     uv build
 
+# live preview of the current working tree (single version)
 docs:
     uv run --group docs mkdocs serve
 
 docs-build:
     uv run --group docs mkdocs build --strict
+
+# preview the published multi-version site from the local gh-pages branch
+docs-versions:
+    uv run --group docs mike serve

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,10 +34,17 @@ nav:
 
 markdown_extensions:
   - admonition
+  - md_in_html
   - pymdownx.highlight
   - pymdownx.superfences
   - pymdownx.snippets:
       check_paths: true
+      base_path: ["."]
+
+extra:
+  version:
+    provider: mike
+    alias: true
 
 plugins:
   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "ruff>=0.8",
 ]
 docs = [
+    "mike>=2.1",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.26",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -155,6 +155,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
@@ -172,6 +173,7 @@ dev = [
     { name = "ruff", specifier = ">=0.8" },
 ]
 docs = [
+    { name = "mike", specifier = ">=2.1" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26" },
 ]
@@ -523,6 +525,23 @@ wheels = [
 ]
 
 [[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
+]
+
+[[package]]
 name = "mkdocs"
 version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -754,6 +773,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -1252,6 +1280,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What was broken

The published site was **a Jekyll render of `main`**, not the MkDocs build —
confirmed by `<meta name="generator" content="Jekyll v3.10.0">` on the live
page. Hence the unstyled page, the raw `> *Explicit is better...*` and
`[![CI](...)]` leaking as literal text, and `/api/result/` returning 404.
The correct MkDocs build was sitting unused in `gh-pages` the whole time.

Three independent defects, all fixed here.

## 1. Docs now follow releases, not `main`

Previously `docs.yml` published whatever was on `main`, so the site documented
unreleased code with no way to read the docs for the version you installed.
Now [mike](https://github.com/jimporter/mike) manages versions:

| Version   | Source               | Deployed when                 |
| --------- | -------------------- | ----------------------------- |
| `latest`  | newest release       | a GitHub Release is published |
| `<x.y.z>` | that release, pinned | a GitHub Release is published |
| `dev`     | `main`               | every push to `main`          |

`latest` is the default landing version; Material's version selector is
enabled via `extra.version.provider: mike`.

Two non-obvious details, both found by testing rather than reading docs:

- **`--alias-type=copy` is mandatory.** mike's default alias is a git symlink
  (mode `120000`), which GitHub Pages does not serve — every `/latest/...`
  deep link would have 404'd, reproducing the exact bug being fixed here.
- **The root would 404 before the first release.** `set-default` writes the
  root redirect and only ran on release, so between merging this and cutting a
  release the site root would have been empty. The dev path now falls back to
  `set-default dev` until a release exists.

`--allow-empty` is passed so a `main` push that doesn't change the docs output
doesn't fail the workflow.

## 2. Broken rendering

- `md_in_html` enabled and `markdown="1"` added to the README badge `<div>`.
  Python-Markdown leaves markdown inside raw HTML blocks unprocessed — that is
  what mangled the Zen quote and the badges. GitHub ignores the attribute, so
  the README renders unchanged there.
- `docs/index.md` now includes only a marked region of `README.md`, dropping
  the GitHub-only title, badges and table of contents. That ToC also had
  anchors that don't exist under MkDocs' slugifier.

## 3. Broken links

README deep links now point at `/latest/api/...` — the URL that matters for
people running the released version.

## Verification

Everything below was executed, not assumed. A scratch bare repo stood in for
`origin`:

- full lifecycle: dev-only deploy → release deploy → repeated pushes; exit
  codes checked at each step
- resulting `gh-pages` layout: `1.0.0/`, `dev/`, `latest/` (a real directory,
  not a symlink), `versions.json`, root redirect
- root redirect verified to point at `dev/` before a release and `latest/`
  after one
- every documented URL served over HTTP: `/`, `/versions.json`, `/latest/`,
  `/latest/api/{result,iterator,async-iterator}/`, `/latest/changelog/`,
  `/dev/api/result/`, `/1.0.0/api/result/` — all 200
- `mkdocs build --strict`, ruff check + format, 395 tests incl. README blocks

## Housekeeping

The old `gh-pages` branch was deleted. It held a flat unversioned build
created by the previous `docs.yml` run; left in place, its stale root
`api/`, `assets/` and `changelog/` would have kept serving outdated content
next to the versioned site. CI recreates the branch cleanly on merge.

## After merge

1. The `Docs` workflow runs and creates `gh-pages` with `dev`.
2. **Settings → Pages → Source: `Deploy from a branch`, branch `gh-pages`,
   folder `/ (root)`.** This is the only supported setting — mike publishes to
   that branch, so the `GitHub Actions` source cannot serve it.
3. Publishing the 1.0.0 release then creates `latest` and repoints the root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
