### PR TITLE
fix(ci): chain publish and release docs from release-please

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,23 @@
 ---
+# The release path is invoked by release-please.yml, not by `on: release`:
+# release-please creates the release with GITHUB_TOKEN, and GitHub does not
+# start workflows from events raised by that token.
 on:
   push:
     branches:
       - main
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      version:
+        description: Release tag to publish and alias as `latest`
+        required: true
+        type: string
   workflow_dispatch:
+    inputs:
+      version:
+        description: Release tag to publish as `latest` (empty deploys `dev`)
+        required: false
+        type: string
 
 name: Docs
 
@@ -43,9 +55,9 @@ jobs:
       # --alias-type=copy is required: mike's default symlink alias is not
       # served by GitHub Pages, which would 404 every /latest/... deep link.
       - name: Deploy release docs
-        if: github.event_name == 'release'
+        if: inputs.version != ''
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ inputs.version }}
         run: |
           version="${TAG#v}"
           uv run --locked --group docs mike deploy --push --update-aliases \
@@ -55,7 +67,7 @@ jobs:
       # main documents unreleased code, published separately as `dev` so it can
       # never be mistaken for the released API.
       - name: Deploy dev docs
-        if: github.event_name != 'release'
+        if: inputs.version == ''
         run: |
           uv run --locked --group docs mike deploy --push --allow-empty dev
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,13 @@
 ---
+# Invoked by release-please.yml once a release is actually created.
+#
+# Deliberately NOT `on: release: published`: release-please creates the release
+# with GITHUB_TOKEN, and GitHub does not start workflows from events raised by
+# that token, so a release trigger would silently never fire. Every successful
+# publish in this repo's history was a manual workflow_dispatch for that reason.
 on:
-  release:
-    types: [published]
+  workflow_call:
+  workflow_dispatch:
 
 name: Publish to PyPI
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,9 @@ permissions:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v5
         id: release
@@ -40,3 +43,23 @@ jobs:
             git commit -m "chore: update uv.lock"
             git push
           fi
+
+  # The release above is created with GITHUB_TOKEN, and GitHub does not start
+  # workflows from events raised by that token — so `on: release: published`
+  # never fires. Publishing and the release docs are chained explicitly instead.
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/publish.yml
+
+  docs:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/docs.yml
+    with:
+      version: ${{ needs.release-please.outputs.tag_name }}

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -106,7 +106,7 @@ async def collect(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def fetch(i: int) -> Result[int, str]:
         ...     return Ok(i) if i > 0 else Err("bad")
@@ -183,7 +183,7 @@ async def map_collect(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def double(x: int) -> Result[int, str]:
         ...     return Ok(x * 2)
@@ -217,7 +217,7 @@ async def partition(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def fetch(i: int) -> Result[int, str]:
         ...     return Ok(i) if i > 0 else Err(f"bad: {i}")
@@ -278,7 +278,7 @@ async def map_partition(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def check(i: int) -> Result[int, str]:
         ...     return Ok(i) if i > 0 else Err(f"bad: {i}")
@@ -314,7 +314,7 @@ async def collect_all(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def fetch(i: int) -> Result[int, str]:
         ...     return Ok(i) if i > 0 else Err(f"bad: {i}")
@@ -353,10 +353,12 @@ async def filter_ok_unordered(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example::
-
+    Examples:
+        ```python
         async for user in filter_ok_unordered([fetch(1), fetch(2), fetch(3)]):
             print(user)
+        ```
+
     """
     it = iter(iterable)
     pending: set[asyncio.Task[Result[T, E]]] = {
@@ -408,10 +410,12 @@ async def filter_err_unordered(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example::
-
+    Examples:
+        ```python
         async for err in filter_err_unordered([fetch(1), fetch(2), fetch(3)]):
             print(err)
+        ```
+
     """
     it = iter(iterable)
     pending: set[asyncio.Task[Result[T, E]]] = {
@@ -465,10 +469,12 @@ async def filter_ok(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example::
-
+    Examples:
+        ```python
         async for user in filter_ok([fetch(1), fetch(2), fetch(3)], concurrency=4):
             print(user)
+        ```
+
     """
     it = iter(iterable)
     pending, next_idx = _make_pending_indexed(it, concurrency)
@@ -526,10 +532,12 @@ async def filter_err(
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
 
-    Example::
-
+    Examples:
+        ```python
         async for err in filter_err([fetch(1), fetch(2), fetch(3)], concurrency=4):
             print(err)
+        ```
+
     """
     it = iter(iterable)
     pending, next_idx = _make_pending_indexed(it, concurrency)
@@ -581,7 +589,7 @@ async def try_reduce(
     only one coroutine can fail — so exceptions propagate bare, without an
     ``ExceptionGroup``.
 
-    Example:
+    Examples:
         >>> import asyncio
         >>> async def fetch(i: int) -> int:
         ...     return i

--- a/src/corrode/iterator.py
+++ b/src/corrode/iterator.py
@@ -19,7 +19,7 @@ def collect(iterable: Iterable[Result[T, E]]) -> Result[list[T], E]:
 
     Returns the first ``Err`` encountered, short-circuiting the iteration.
 
-    Example:
+    Examples:
         >>> collect([Ok(1), Ok(2), Ok(3)])
         Ok([1, 2, 3])
         >>> collect([Ok(1), Err("bad"), Ok(3)])
@@ -47,7 +47,7 @@ def collect_all(iterable: Iterable[Result[T, E]]) -> Result[list[T], list[E]]:
     the outcome is a ``Result``: "all succeeded" and "something failed" are
     distinct variants instead of an empty-list check.
 
-    Example:
+    Examples:
         >>> collect_all([Ok(1), Ok(2), Ok(3)])
         Ok([1, 2, 3])
         >>> collect_all([Ok(1), Err("a"), Ok(3), Err("b")])
@@ -69,7 +69,7 @@ def map_collect(
 
     Returns the first ``Err`` produced by *f*, short-circuiting the iteration.
 
-    Example:
+    Examples:
         >>> def parse(s: str) -> Result[int, str]:
         ...     return Ok(int(s)) if s.isdigit() else Err(f"not a number: {s!r}")
         >>> map_collect(["1", "2", "3"], parse)
@@ -96,7 +96,7 @@ def partition(
 
     Consumes all elements without short-circuiting.
 
-    Example:
+    Examples:
         >>> partition([Ok(1), Err("a"), Ok(2), Err("b")])
         ([1, 2], ['a', 'b'])
 
@@ -121,7 +121,7 @@ def map_partition(
 
     Consumes all elements without short-circuiting.
 
-    Example:
+    Examples:
         >>> def parse(s: str) -> Result[int, str]:
         ...     return Ok(int(s)) if s.isdigit() else Err(f"not a number: {s!r}")
         >>> map_partition(["1", "x", "3"], parse)
@@ -135,7 +135,7 @@ def filter_ok(iterable: Iterable[Result[T, E]]) -> Iterator[T]:
     """
     Yield the value from each ``Ok``, skipping ``Err`` values.
 
-    Example:
+    Examples:
         >>> list(filter_ok([Ok(1), Err("x"), Ok(2)]))
         [1, 2]
 
@@ -150,7 +150,7 @@ def filter_err(iterable: Iterable[Result[T, E]]) -> Iterator[E]:
     """
     Yield the error from each ``Err``, skipping ``Ok`` values.
 
-    Example:
+    Examples:
         >>> list(filter_err([Ok(1), Err("x"), Ok(2), Err("y")]))
         ['x', 'y']
 
@@ -169,7 +169,7 @@ def try_reduce(
     """
     Fold *iterable* with *f*, short-circuiting on ``Err``.
 
-    Example:
+    Examples:
         >>> def safe_add(acc: int, x: int) -> Result[int, str]:
         ...     return Err(f"negative value: {x}") if x < 0 else Ok(acc + x)
         >>> try_reduce([1, 2, 3], 0, safe_add)

--- a/src/corrode/result.py
+++ b/src/corrode/result.py
@@ -86,7 +86,7 @@ class Ok(Generic[T_co]):
         """
         Return ``True`` because this is an ``Ok`` value.
 
-        Example:
+        Examples:
             >>> Ok(2).is_ok()
             True
 
@@ -97,7 +97,7 @@ class Ok(Generic[T_co]):
         """
         Return ``False`` because this is an ``Ok`` value.
 
-        Example:
+        Examples:
             >>> Ok(2).is_err()
             False
 
@@ -108,7 +108,7 @@ class Ok(Generic[T_co]):
         """
         Return ``True`` if the result is ``Ok`` and the predicate *f* returns ``True``.
 
-        Example:
+        Examples:
             >>> Ok(2).is_ok_and(lambda x: x > 1)
             True
             >>> Ok(0).is_ok_and(lambda x: x > 1)
@@ -127,7 +127,7 @@ class Ok(Generic[T_co]):
 
         Since this is ``Ok``, always returns ``False``.
 
-        Example:
+        Examples:
             >>> Ok(2).is_err_and(lambda e: True)
             False
 
@@ -148,7 +148,7 @@ class Ok(Generic[T_co]):
 
         Return the contained ``Ok`` value, discarding the error, if any.
 
-        Example:
+        Examples:
             >>> Ok(2).ok()
             2
 
@@ -161,7 +161,7 @@ class Ok(Generic[T_co]):
 
         Return ``None``, discarding the success value.
 
-        Example:
+        Examples:
             >>> Ok(2).err() is None
             True
 
@@ -173,7 +173,7 @@ class Ok(Generic[T_co]):
         """
         The contained ``Ok`` value.
 
-        Example:
+        Examples:
             >>> Ok(2).ok_value
             2
 
@@ -189,7 +189,7 @@ class Ok(Generic[T_co]):
         Raises:
             UnwrapError: Never raised for ``Ok``.
 
-        Example:
+        Examples:
             >>> Ok(2).expect("must exist")
             2
 
@@ -204,7 +204,7 @@ class Ok(Generic[T_co]):
             UnwrapError: Always, because this is an ``Ok`` value, with a
                 message including the passed *message* and the ``Ok`` content.
 
-        Example:
+        Examples:
             >>> Ok(2).expect_err("wanted an error")
             Traceback (most recent call last):
                 ...
@@ -222,7 +222,7 @@ class Ok(Generic[T_co]):
         Raises:
             UnwrapError: Never raised for ``Ok``.
 
-        Example:
+        Examples:
             >>> Ok(2).unwrap()
             2
 
@@ -236,7 +236,7 @@ class Ok(Generic[T_co]):
         Raises:
             UnwrapError: Always, because this is an ``Ok`` value.
 
-        Example:
+        Examples:
             >>> Ok(2).unwrap_err()
             Traceback (most recent call last):
                 ...
@@ -251,7 +251,7 @@ class Ok(Generic[T_co]):
 
         The default value is ignored because this is an ``Ok``.
 
-        Example:
+        Examples:
             >>> Ok(2).unwrap_or(0)
             2
 
@@ -264,7 +264,7 @@ class Ok(Generic[T_co]):
 
         The callable is never invoked because this is an ``Ok``.
 
-        Example:
+        Examples:
             >>> Ok(2).unwrap_or_else(len)
             2
 
@@ -285,7 +285,7 @@ class Ok(Generic[T_co]):
 
         The exception is never raised because this is an ``Ok``.
 
-        Example:
+        Examples:
             >>> Ok(2).unwrap_or_raise(ValueError)
             2
 
@@ -298,7 +298,7 @@ class Ok(Generic[T_co]):
 
         Map a ``Result[T, E]`` to ``Result[U, E]``, leaving an ``Err`` value untouched.
 
-        Example:
+        Examples:
             >>> Ok(2).map(lambda x: x * 10)
             Ok(20)
 
@@ -319,7 +319,7 @@ class Ok(Generic[T_co]):
 
         Since this is ``Ok``, *default* is ignored.
 
-        Example:
+        Examples:
             >>> Ok(2).map_or(0, lambda x: x * 10)
             20
 
@@ -340,7 +340,7 @@ class Ok(Generic[T_co]):
 
         Map a ``Result[T, E]`` to ``U``.
 
-        Example:
+        Examples:
             >>> Ok(2).map_or_else(lambda e: 0, lambda x: x * 10)
             20
 
@@ -365,7 +365,7 @@ class Ok(Generic[T_co]):
 
         Map a ``Result[T, E]`` to ``Result[T, F]``.
 
-        Example:
+        Examples:
             >>> Ok(2).map_err(str.upper)
             Ok(2)
 
@@ -386,7 +386,7 @@ class Ok(Generic[T_co]):
 
         This function can be used for control flow based on ``Result`` values.
 
-        Example:
+        Examples:
             >>> def halve(x: int) -> Result[int, str]:
             ...     return Ok(x // 2) if x % 2 == 0 else Err("odd")
             >>> Ok(4).and_then(halve)
@@ -414,7 +414,7 @@ class Ok(Generic[T_co]):
 
         Since this is ``Ok``, *op* is never called.
 
-        Example:
+        Examples:
             >>> Ok(2).or_else(lambda e: Ok(0))
             Ok(2)
 
@@ -435,7 +435,7 @@ class Ok(Generic[T_co]):
 
         Return the original result unchanged.
 
-        Example:
+        Examples:
             >>> Ok(2).inspect(print)
             2
             Ok(2)
@@ -463,7 +463,7 @@ class Ok(Generic[T_co]):
 
         Return the original result unchanged. Since this is ``Ok``, *op* is not called.
 
-        Example:
+        Examples:
             >>> Ok(2).inspect_err(print)
             Ok(2)
 
@@ -515,7 +515,7 @@ class Ok(Generic[T_co]):
         Returns ``Ok`` of a tuple of all values if all results are ``Ok``.
         Returns the first ``Err`` encountered otherwise.
 
-        Example:
+        Examples:
             >>> Ok(1).zip(Ok("a"))
             Ok((1, 'a'))
             >>> Ok(1).zip(Ok("a"), Ok(3.0))
@@ -540,7 +540,7 @@ class Ok(Generic[T_co]):
         Convert ``Result[Result[U, F], E]`` into ``Result[U, F]``.
         Only one level is removed — ``Ok(Ok(Ok(1))).flatten()`` is ``Ok(Ok(1))``.
 
-        Example:
+        Examples:
             >>> Ok(Ok(1)).flatten()
             Ok(1)
             >>> Ok(Err("bad")).flatten()
@@ -624,7 +624,7 @@ class Err(Generic[E_co]):
         """
         Return ``False`` because this is an ``Err`` value.
 
-        Example:
+        Examples:
             >>> Err("boom").is_ok()
             False
 
@@ -635,7 +635,7 @@ class Err(Generic[E_co]):
         """
         Return ``True`` because this is an ``Err`` value.
 
-        Example:
+        Examples:
             >>> Err("boom").is_err()
             True
 
@@ -648,7 +648,7 @@ class Err(Generic[E_co]):
 
         Since this is ``Err``, always returns ``False``.
 
-        Example:
+        Examples:
             >>> Err("boom").is_ok_and(lambda x: True)
             False
 
@@ -667,7 +667,7 @@ class Err(Generic[E_co]):
         """
         Return ``True`` if the result is ``Err`` and the predicate *f* returns ``True``.
 
-        Example:
+        Examples:
             >>> Err("boom").is_err_and(lambda e: "boo" in e)
             True
             >>> Err("boom").is_err_and(lambda e: e == "x")
@@ -686,7 +686,7 @@ class Err(Generic[E_co]):
 
         Return ``None``, discarding the error value.
 
-        Example:
+        Examples:
             >>> Err("boom").ok() is None
             True
 
@@ -699,7 +699,7 @@ class Err(Generic[E_co]):
 
         Return the contained ``Err`` value, discarding the success value, if any.
 
-        Example:
+        Examples:
             >>> Err("boom").err()
             'boom'
 
@@ -711,7 +711,7 @@ class Err(Generic[E_co]):
         """
         The contained ``Err`` value.
 
-        Example:
+        Examples:
             >>> Err("boom").err_value
             'boom'
 
@@ -726,7 +726,7 @@ class Err(Generic[E_co]):
             UnwrapError: Always, because this is an ``Err`` value, with a
                 message including the passed *message* and the ``Err`` content.
 
-        Example:
+        Examples:
             >>> Err("boom").expect("must exist")
             Traceback (most recent call last):
                 ...
@@ -750,7 +750,7 @@ class Err(Generic[E_co]):
         Raises:
             UnwrapError: Never raised for ``Err``.
 
-        Example:
+        Examples:
             >>> Err("boom").expect_err("wanted an error")
             'boom'
 
@@ -765,7 +765,7 @@ class Err(Generic[E_co]):
             UnwrapError: Always, because this is an ``Err`` value, with a
                 message provided by the ``Err`` content.
 
-        Example:
+        Examples:
             >>> Err("boom").unwrap()
             Traceback (most recent call last):
                 ...
@@ -789,7 +789,7 @@ class Err(Generic[E_co]):
         Raises:
             UnwrapError: Never raised for ``Err``.
 
-        Example:
+        Examples:
             >>> Err("boom").unwrap_err()
             'boom'
 
@@ -802,7 +802,7 @@ class Err(Generic[E_co]):
 
         The contained ``Err`` value is discarded.
 
-        Example:
+        Examples:
             >>> Err("boom").unwrap_or(0)
             0
 
@@ -815,7 +815,7 @@ class Err(Generic[E_co]):
 
         The callable *op* is applied to the contained ``Err`` value.
 
-        Example:
+        Examples:
             >>> Err("boom").unwrap_or_else(len)
             4
 
@@ -836,7 +836,7 @@ class Err(Generic[E_co]):
 
         The exception *e* is instantiated with the ``Err`` value and raised.
 
-        Example:
+        Examples:
             >>> Err("boom").unwrap_or_raise(ValueError)
             Traceback (most recent call last):
                 ...
@@ -851,7 +851,7 @@ class Err(Generic[E_co]):
 
         Map a ``Result[T, E]`` to ``Result[U, E]``, leaving an ``Err`` value untouched.
 
-        Example:
+        Examples:
             >>> Err("boom").map(lambda x: x * 10)
             Err('boom')
 
@@ -872,7 +872,7 @@ class Err(Generic[E_co]):
 
         Since this is ``Err``, *op* is ignored and *default* is returned.
 
-        Example:
+        Examples:
             >>> Err("boom").map_or(0, lambda x: x * 10)
             0
 
@@ -893,7 +893,7 @@ class Err(Generic[E_co]):
 
         Map a ``Result[T, E]`` to ``U``.
 
-        Example:
+        Examples:
             >>> Err("boom").map_or_else(len, lambda x: x * 10)
             4
 
@@ -918,7 +918,7 @@ class Err(Generic[E_co]):
 
         Map a ``Result[T, E]`` to ``Result[T, F]``.
 
-        Example:
+        Examples:
             >>> Err("boom").map_err(str.upper)
             Err('BOOM')
 
@@ -939,7 +939,7 @@ class Err(Generic[E_co]):
 
         This function can be used for control flow based on ``Result`` values.
 
-        Example:
+        Examples:
             >>> Err("boom").and_then(lambda x: Ok(x * 10))
             Err('boom')
 
@@ -960,7 +960,7 @@ class Err(Generic[E_co]):
 
         Since this is ``Err``, *op* is called with the error value.
 
-        Example:
+        Examples:
             >>> Err("boom").or_else(lambda e: Ok(len(e)))
             Ok(4)
 
@@ -984,7 +984,7 @@ class Err(Generic[E_co]):
 
         Return the original result unchanged. Since this is ``Err``, *op* is not called.
 
-        Example:
+        Examples:
             >>> Err("boom").inspect(print)
             Err('boom')
 
@@ -1005,7 +1005,7 @@ class Err(Generic[E_co]):
 
         Return the original result unchanged.
 
-        Example:
+        Examples:
             >>> Err("boom").inspect_err(print)
             boom
             Err('boom')
@@ -1033,7 +1033,7 @@ class Err(Generic[E_co]):
 
         Since this is an ``Err``, always returns ``self`` without inspecting the others.
 
-        Example:
+        Examples:
             >>> Err("bad").zip(Ok(1))
             Err('bad')
             >>> Err("bad").zip(Ok(1), Ok(2))
@@ -1048,7 +1048,7 @@ class Err(Generic[E_co]):
 
         Since this is an ``Err``, there is nothing to flatten — ``self`` is returned.
 
-        Example:
+        Examples:
             >>> Err("bad").flatten()
             Err('bad')
 
@@ -1100,7 +1100,7 @@ def as_result(
     (``KeyboardInterrupt``, ``SystemExit``, ``asyncio.CancelledError``) must
     propagate — swallowing them breaks interrupts and task cancellation.
 
-    Example:
+    Examples:
         >>> @as_result(ValueError)
         ... def parse(s: str) -> int:
         ...     return int(s)
@@ -1180,7 +1180,7 @@ def from_optional(value: U | None, error: F) -> Result[U, F]:
     ``Result``. Note that ``Ok(None)`` cannot be produced — if ``None`` is a
     valid success value for you, construct the ``Result`` explicitly.
 
-    Example:
+    Examples:
         >>> from_optional(42, "missing")
         Ok(42)
         >>> from_optional(None, "missing")
@@ -1199,7 +1199,7 @@ def from_optional_or_else(value: U | None, error_fn: Callable[[], F]) -> Result[
     Like ``from_optional``, but *error_fn* is only called when *value* is
     ``None`` — use it when constructing the error is expensive.
 
-    Example:
+    Examples:
         >>> from_optional_or_else(42, lambda: "missing")
         Ok(42)
         >>> from_optional_or_else(None, lambda: "missing")
@@ -1223,7 +1223,7 @@ def is_ok(result: Result[T_co, E_co]) -> TypeIs[Ok[T_co]]:
         elif is_err(r):
             r  # r is of type Err[str]
 
-    Example:
+    Examples:
         >>> is_ok(Ok(1))
         True
         >>> is_ok(Err("boom"))
@@ -1245,7 +1245,7 @@ def is_err(result: Result[T_co, E_co]) -> TypeIs[Err[E_co]]:
         elif is_err(r):
             r  # r is of type Err[str]
 
-    Example:
+    Examples:
         >>> is_err(Err("boom"))
         True
         >>> is_err(Ok(1))


### PR DESCRIPTION
## The release did not publish anything

`v1.0.0` was tagged and a GitHub Release was created, but the package never
reached PyPI and the docs never got a `latest` version — `gh-pages` still had
only `dev`.

**Root cause:** GitHub does not start workflows from events raised by
`GITHUB_TOKEN`. release-please creates the release with that token, so
`on: release: published` never fires. It never has in this repo — every
successful publish in the history ran as a manual `workflow_dispatch`:

```
2026-02-19  event=workflow_dispatch  success
2026-02-19  event=workflow_dispatch  success
2026-02-16  event=push               success
```

Removing `workflow_dispatch` from `publish.yml` in 419156e therefore closed the
only path that actually worked, while the automatic one had been dead all
along. My regression, on both counts.

## Fix

`publish.yml` and `docs.yml` become reusable workflows, invoked by
`release-please.yml` when its `release_created` output is `true`. No PAT
needed. `workflow_dispatch` is restored on both as a manual fallback.

One non-obvious detail: inside a reusable workflow `github.event_name` is the
**caller's** event, so `docs.yml` can no longer tell a release from a push to
`main`. The `version` input discriminates instead — set on the release path,
empty for `dev`.

## Doctest rendering in the API reference

Reported broken on `/dev/api/iterator/`: examples collapsed into a single
unreadable paragraph.

griffe only recognises `Examples:` (plural) as a Google-style section. The
singular `Example:` fell through as an unknown section and was rendered as an
admonition whose contents were flattened into prose. All 66 sections renamed;
the four RST-style `Example::` blocks in the async generators became fenced
`python` blocks.

Verified against the built HTML rather than by eye — zero `<p>` paragraphs
containing a doctest prompt across all three API pages, and every example now
carries pygments prompt/output markup.

## Verification

395 tests, 100% coverage, all four type checkers, ruff check + format,
`mkdocs build --strict`, workflow YAML parsed.

## After merge

`v1.0.0` is already tagged, so release-please will not re-release it. I will
dispatch `publish.yml` and `docs.yml` manually once to land 1.0.0 on PyPI and
create the `latest` docs; every future release is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)