### PR TITLE
chore(ci): fail the build when coverage upload fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,16 @@ jobs:
       - name: Run tests
         run: uv run pytest ${{ matrix.python == '3.14' && '--cov=corrode --cov-report=xml' || '' }}
 
+      # fail_ci_if_error defaults to false, which let a rejected upload
+      # ("Token required - not valid tokenless upload") pass as a green build
+      # while the coverage badge sat at "unknown". A broken upload is a broken
+      # build: errors should never pass silently.
       - name: Upload coverage to codecov.io
         uses: codecov/codecov-action@v7
         if: matrix.python == '3.14'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
   typecheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The coverage badge read `unknown`. The cause was in the CI log all along:

```
info  -- Found 1 coverage files to report
info  -- Upload queued for processing complete
error -- Upload queued for processing failed: {"message":"Token required - not valid tokenless upload"}
```

`CODECOV_TOKEN` was not set, so every upload was rejected — but
`codecov-action` defaults `fail_ci_if_error` to `false`, so the job stayed
green and nobody found out. The badge silently rotted instead.

The token has since been added to the repository secrets and a re-run
confirmed the upload now succeeds; the badge reports `100%`.

## Fix

Set `fail_ci_if_error: true` so a rejected upload fails the build.

The trade-off is that a codecov outage will now turn CI red. That is the right
side to err on for this project: a silent failure cost a badge that was wrong
for months, and "errors should never pass silently" is literally the README
epigraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)