### PR TITLE
docs: add a downloads/month badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Rust-like `Result` type for Python 3.11+, fully type annotated.
 [![CI](https://github.com/deliro/corrode/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/deliro/corrode/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/deliro/corrode/branch/main/graph/badge.svg)](https://codecov.io/gh/deliro/corrode)
 [![PyPI](https://img.shields.io/pypi/v/corrode)](https://pypi.org/project/corrode/)
+[![Downloads](https://img.shields.io/pypi/dm/corrode)](https://pypistats.org/packages/corrode)
 [![Python versions](https://img.shields.io/pypi/pyversions/corrode)](https://pypi.org/project/corrode/)
 
 </div>


### PR DESCRIPTION
Adds `![Downloads](https://img.shields.io/pypi/dm/corrode)` next to the version
badge.

Two small decisions:

- **Monthly, not daily.** `pypi/dd` currently answers `rate limited by upstream
  service`, so a daily badge would render as an error for visitors. `pypi/dm`
  returns real data (`361/month` at the time of writing).
- **Links to pypistats, not PyPI.** The badge shows a download count, so the
  link leads to where that count comes from rather than to the project page,
  which the version badge next to it already covers.

Verified: README code blocks still execute and type-check, `mkdocs build
--strict` passes, and the badge block stays outside the region included by the
docs site (`img.shields.io` does not appear in the built `index.html`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)