### PR TITLE
feat!: new combinators — transpose, zip, first_ok, async sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ doctest in CI.
 - [Strict by design](#strict-by-design)
 - [Iterator utilities](#iterator-utilities)
 - [Async iterator utilities](#async-iterator-utilities)
+  - [Racing alternatives](#racing-alternatives)
+  - [Fan-out over different types](#fan-out-over-different-types)
+  - [Streaming sources](#streaming-sources)
   - [Exceptions and `ExceptionGroup`](#exceptions-and-exceptiongroup)
 - [Adopting corrode in an existing codebase](#adopting-corrode-in-an-existing-codebase)
 - [Typing](#typing)
@@ -235,6 +238,20 @@ assert find_product("mate").zip(parse_qty("no")) == Err("unknown product: mate")
 assert find_product("mate").or_else(lambda _: find_product("tea")) == Ok(tea)
 assert find_product("tea").or_else(lambda _: find_product("mate")) == Ok(tea)
 
+
+# A lookup can both fail and legitimately find nothing. transpose moves the
+# "nothing" out of the Result, so "this order has no coupon" stays a separate
+# case from "the coupon service is down" instead of hiding inside Ok(None)
+def find_coupon(order: str) -> Result[int | None, str]:
+    if order == "broken":
+        return Err("coupon service unavailable")
+    return Ok(500 if order == "tea" else None)
+
+
+assert find_coupon("tea").transpose() == Ok(500)
+assert find_coupon("mate").transpose() is None
+assert find_coupon("broken").transpose() == Err("coupon service unavailable")
+
 # Results are ordinary values, so they can be stored. Reading one back
 # yields nesting, which flatten collapses — keeping "no such order",
 # "the order failed", and "the order succeeded" distinct
@@ -340,6 +357,55 @@ assert collect_all([parse("1"), parse("x"), parse("y")]) == Err(
 assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a number: 'x'"])
 ```
 
+`first_ok` is the mirror image of `collect`: it takes the first success and
+keeps every failure. Typical use is a fallback chain — several ways to obtain
+the same thing, tried in order of preference:
+
+```python
+from dataclasses import dataclass
+from corrode import Ok, Err, Result
+from corrode.iterator import first_ok
+
+
+@dataclass(frozen=True)
+class Payment:
+    order: str
+    cents: int
+
+
+# Two payload versions are in flight during a producer rollout
+def parse_v2(raw: dict[str, object]) -> Result[Payment, str]:
+    match raw:
+        case {"order_id": str(order), "amount_cents": int(cents)}:
+            return Ok(Payment(order=order, cents=cents))
+    return Err("v2: expected order_id and integer amount_cents")
+
+
+def parse_v1(raw: dict[str, object]) -> Result[Payment, str]:
+    match raw:
+        case {"order": str(order), "amount": str(amount)}:
+            return Ok(Payment(order=order, cents=round(float(amount) * 100)))
+    return Err("v1: expected order and decimal amount")
+
+
+def parse_webhook(raw: dict[str, object]) -> Result[Payment, list[str]]:
+    # A generator, so the fallback is lazy: parse_v1 is never called for a
+    # payload that is already v2. With one parser per schema, nothing forces
+    # the caller to know which version it is looking at.
+    return first_ok(parse(raw) for parse in (parse_v2, parse_v1))
+
+
+assert parse_webhook({"order_id": "A-1", "amount_cents": 990}) == Ok(Payment("A-1", 990))
+assert parse_webhook({"order": "A-1", "amount": "9.90"}) == Ok(Payment("A-1", 990))
+
+# Nothing matched. The rejection can be logged with every reason at once —
+# with a plain `or` chain only the last failure survives, which is exactly
+# the one that says the least about a payload that was never v1 to begin with
+assert parse_webhook({"orderId": "A-1"}) == Err(
+    ["v2: expected order_id and integer amount_cents", "v1: expected order and decimal amount"]
+)
+```
+
 ## Async iterator utilities
 
 `corrode.async_iterator` runs coroutines or tasks concurrently
@@ -393,6 +459,195 @@ async def main() -> None:
     # Error accumulation: every failure is reported, nothing is cancelled
     report = await collect_all([fetch_user(1), fetch_user(-1), fetch_user(-2)])
     assert report == Err(["bad id: -1", "bad id: -2"])
+
+
+asyncio.run(main())
+```
+
+### Racing alternatives
+
+When the same thing can be fetched from several places, `first_ok` sends the
+requests at once and returns the first success, cancelling the rest. The
+losers are cancelled, not left running in the background, so the cost of the
+extra attempts is bounded by the winner's latency.
+
+Two details make it different from `asyncio.wait(..., FIRST_COMPLETED)`:
+a returned `Err` does **not** win the race — a mirror that answers "404" in a
+millisecond must not beat the mirror that has the file — and if every
+alternative fails, the caller gets *all* the errors, which is the difference
+between a log line saying "download failed" and one that says which mirror
+said what.
+
+```python
+import asyncio
+from dataclasses import dataclass
+from corrode import Ok, Err, Result
+from corrode.async_iterator import first_ok
+
+
+@dataclass(frozen=True)
+class Mirror:
+    host: str
+    latency: float  # stands in for the network round-trip
+    artifacts: frozenset[str]
+
+
+MIRRORS = (
+    Mirror("eu.cdn.example", 0.05, frozenset({"app-1.2.3.tar"})),
+    Mirror("us.cdn.example", 0.02, frozenset({"app-1.2.3.tar"})),
+    # Fast to answer, but this region has not replicated the release yet
+    Mirror("ap.cdn.example", 0.01, frozenset()),
+)
+
+
+async def download(mirror: Mirror, artifact: str) -> Result[bytes, str]:
+    await asyncio.sleep(mirror.latency)
+    if artifact not in mirror.artifacts:
+        return Err(f"{mirror.host}: 404 {artifact}")
+    return Ok(f"{artifact} via {mirror.host}".encode())
+
+
+async def main() -> None:
+    # The 404 from ap arrives first and is recorded, not returned; us wins
+    # the race and eu is cancelled mid-flight
+    release = await first_ok([download(m, "app-1.2.3.tar") for m in MIRRORS])
+    assert release == Ok(b"app-1.2.3.tar via us.cdn.example")
+
+    # Nowhere to be found: one report, every mirror, in input order
+    missing = await first_ok([download(m, "app-9.9.9.tar") for m in MIRRORS])
+    assert missing == Err(
+        [
+            "eu.cdn.example: 404 app-9.9.9.tar",
+            "us.cdn.example: 404 app-9.9.9.tar",
+            "ap.cdn.example: 404 app-9.9.9.tar",
+        ]
+    )
+
+
+asyncio.run(main())
+```
+
+### Fan-out over different types
+
+`collect` needs a homogeneous list. Assembling one page out of several
+unrelated calls is the heterogeneous case: `zip` takes 2–5 awaitables of
+different types and returns a typed tuple, or the first `Err` — with the
+remaining calls cancelled, so a checkout that already failed on the profile
+does not keep charging the shipping API.
+
+Compared to `asyncio.gather`, the values stay typed instead of collapsing
+into `list[Any]`, and an expected failure ("card declined") stays a value
+instead of becoming an exception that has to be told apart from a bug.
+
+```python
+import asyncio
+from dataclasses import dataclass
+from corrode import Ok, Err, Result, async_iterator
+
+
+@dataclass(frozen=True)
+class Profile:
+    name: str
+    tier: str
+
+
+@dataclass(frozen=True)
+class Quote:
+    carrier: str
+    cents: int
+
+
+completed: list[str] = []
+
+
+async def load_profile(user_id: int) -> Result[Profile, str]:
+    return Ok(Profile(name="Alice", tier="gold"))
+
+
+async def load_balance(user_id: int) -> Result[int, str]:
+    return Err("billing: card declined") if user_id == 13 else Ok(2500)
+
+
+async def shipping_quote(user_id: int) -> Result[Quote, str]:
+    await asyncio.sleep(0.05)  # the slowest upstream
+    completed.append("shipping")
+    return Ok(Quote(carrier="dhl", cents=490))
+
+
+async def checkout(user_id: int) -> Result[tuple[Profile, int, Quote], str]:
+    # zip shadows the builtin on purpose, mirroring Result.zip — reach for it
+    # through the module to keep the builtin available
+    return await async_iterator.zip(
+        load_profile(user_id),
+        load_balance(user_id),
+        shipping_quote(user_id),
+    )
+
+
+async def main() -> None:
+    page = await checkout(user_id=1)
+    assert page == Ok((Profile("Alice", "gold"), 2500, Quote("dhl", 490)))
+
+    # The declined card ends the checkout, and the shipping call is cancelled
+    # rather than left to finish into a response nobody will read
+    assert await checkout(user_id=13) == Err("billing: card declined")
+    assert completed == ["shipping"]  # only the successful checkout got there
+
+
+asyncio.run(main())
+```
+
+### Streaming sources
+
+Every function here also accepts an async iterable, so the work does not have
+to be listed up front. The usual source is a paginated API or a database
+cursor: materialising it first (`[x async for x in pages()]`) means crawling
+the whole thing into memory before the first item is processed, and the
+concurrency limit then applies to nothing.
+
+Passing the async generator directly keeps the two interleaved — pages are
+pulled only as workers free up, so at most `concurrency` requests are in
+flight and memory stays bounded no matter how many pages there are.
+
+```python
+import asyncio
+from collections.abc import AsyncIterator
+from corrode import Ok, Result
+from corrode.async_iterator import map_collect
+
+PAGES: dict[str | None, tuple[list[int], str | None]] = {
+    None: ([1, 2, 3], "cursor-2"),
+    "cursor-2": ([4, 5, 6], "cursor-3"),
+    "cursor-3": ([7, 8], None),
+}
+
+
+async def list_orders(cursor: str | None) -> tuple[list[int], str | None]:
+    await asyncio.sleep(0.01)  # one round-trip per page
+    return PAGES[cursor]
+
+
+async def order_ids() -> AsyncIterator[int]:
+    cursor: str | None = None
+    while True:
+        page, cursor = await list_orders(cursor)
+        for order_id in page:
+            yield order_id
+        if cursor is None:
+            return
+
+
+async def order_total(order_id: int) -> Result[int, str]:
+    await asyncio.sleep(0.01)
+    return Ok(order_id * 100)
+
+
+async def main() -> None:
+    # Listing and fetching overlap: the totals for page 1 are already being
+    # fetched while page 2 is still being listed. Four in flight at a time,
+    # and the generator is closed on exit even if a fetch fails
+    totals = await map_collect(order_ids(), order_total, concurrency=4)
+    assert totals == Ok([100, 200, 300, 400, 500, 600, 700, 800])
 
 
 asyncio.run(main())

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ assert find_product("mate").map(lambda p: p.price).unwrap_or(0) == 0
 
 Also available — see the [API reference](https://deliro.github.io/corrode/latest/api/result/):
 
-- transforms: `map_err`, `map_or`, `map_or_else`
+- transforms: `map_err`, `map_or`, `map_or_else`, `transpose`
 - predicates: `is_ok`, `is_err`, `is_ok_and`, `is_err_and`
 - side effects: `inspect`, `inspect_err`
 - extraction: `ok`, `err`, `ok_value`, `err_value`, `unwrap`, `expect`,

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ The same principle elsewhere:
 | --------------- | ------------------------------------------------------------------ |
 | `collect`       | all values, or the **first** error (short-circuits)                |
 | `collect_all`   | all values, or **all** errors (never short-circuits)               |
+| `first_ok`      | the **first** value, or **all** errors (short-circuits on success) |
 | `map_collect`   | `collect` with the mapping inline                                  |
 | `partition`     | split into `(oks, errs)`, keep both sides                          |
 | `map_partition` | `partition` with the mapping inline                                |
@@ -348,6 +349,7 @@ assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a numbe
 | ------------------------------------------ | -------------------------------------------------------------- |
 | `collect`                                  | input order; first `Err` cancels the rest                      |
 | `collect_all`                              | input order; all values or **all** errors, runs everything     |
+| `first_ok`                                 | race: first `Ok` to complete wins and cancels the rest, or all errors in input order |
 | `map_collect` / `map_partition`            | `collect` / `partition` with the mapping inline                |
 | `partition`                                | input order; `(oks, errs)`, runs everything                    |
 | `filter_ok_unordered` / `filter_err_unordered` | yield in **completion** order, skip the other side         |

--- a/README.md
+++ b/README.md
@@ -353,9 +353,10 @@ assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a numbe
 | `filter_ok_unordered` / `filter_err_unordered` | yield in **completion** order, skip the other side         |
 | `filter_ok` / `filter_err`                 | yield in **input** order (explicit `concurrency` required)     |
 | `try_reduce`                               | sequential fold, short-circuit on `Err`                        |
+| `zip`                                      | `Result.zip` for 2–5 awaitables: all values as a tuple, or the first `Err` cancels the rest |
 
-Every function accepts `concurrency` to bound how many tasks run at once
-(`None` = unlimited). Every function also takes either a plain iterable or an
+Every iterable-taking function accepts `concurrency` to bound how many tasks run at once
+(`None` = unlimited). Each also takes either a plain iterable or an
 async iterable of awaitables (e.g. an async generator over a paginated API) —
 async sources are consumed lazily and closed on exit. All of them clean up
 after themselves: cancelling the

--- a/README.md
+++ b/README.md
@@ -357,8 +357,9 @@ assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a numbe
 | `try_reduce`                               | sequential fold, short-circuit on `Err`                        |
 | `zip`                                      | `Result.zip` for 2–5 awaitables: all values as a tuple, or the first `Err` cancels the rest |
 
-Every iterable-taking function accepts `concurrency` to bound how many tasks run at once
-(`None` = unlimited). Each also takes either a plain iterable or an
+Every concurrent function takes `concurrency` to bound how many tasks run at once —
+`None` means unlimited, except for `filter_ok` / `filter_err`, which require an explicit
+bound; `try_reduce` is sequential and takes none. Each also takes either a plain iterable or an
 async iterable of awaitables (e.g. an async generator over a paginated API) —
 async sources are consumed lazily and closed on exit. All of them clean up
 after themselves: cancelling the

--- a/README.md
+++ b/README.md
@@ -355,7 +355,10 @@ assert partition([parse("1"), parse("x"), parse("2")]) == ([1, 2], ["not a numbe
 | `try_reduce`                               | sequential fold, short-circuit on `Err`                        |
 
 Every function accepts `concurrency` to bound how many tasks run at once
-(`None` = unlimited). All of them clean up after themselves: cancelling the
+(`None` = unlimited). Every function also takes either a plain iterable or an
+async iterable of awaitables (e.g. an async generator over a paginated API) —
+async sources are consumed lazily and closed on exit. All of them clean up
+after themselves: cancelling the
 caller, breaking out of an `async for`, or an exception in any task cancels
 all in-flight tasks and closes unconsumed coroutines — nothing keeps running
 in the background.

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -573,6 +573,112 @@ async def collect_all(
     return Ok(oks)
 
 
+async def first_ok(
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
+    *,
+    concurrency: int | None = None,
+) -> Result[T, list[E]]:
+    """
+    Race coroutines or tasks concurrently, returning the first ``Ok`` to complete.
+
+    The dual of ``collect``: ``collect`` is all values or the first error,
+    ``first_ok`` is the first value or all errors. Use it to try alternative
+    sources concurrently and take whichever succeeds first.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
+
+    The first ``Ok`` to complete wins: remaining in-flight tasks are cancelled
+    and unconsumed items are closed — slower alternatives are not awaited once
+    one has succeeded. An early ``Err`` does not end the race: it is recorded
+    and the race continues. If every awaitable completes with ``Err``, returns
+    ``Err`` of every error in input order (not completion order); empty input
+    gives ``Err([])``.
+
+    *concurrency* limits how many run at the same time.
+    ``None`` means unlimited — all are scheduled at once.
+
+    **Exceptions**: if any coroutine raises, all remaining tasks are cancelled and
+    every exception — including any raised while those tasks were being cancelled —
+    propagates as a single ``ExceptionGroup``, even when only one task failed.
+    One failure is a group of one: the exception type you catch never depends
+    on timing. Handle with ``except*``.
+    A raising source follows the same contract: in-flight tasks are cancelled
+    and the source's exception joins the group.
+    A raise wins over the race even while other alternatives are still running:
+    it is a bug or an infrastructure failure, not a candidate loser — it is
+    never swallowed on the chance that another branch might still succeed.
+
+    Examples:
+        >>> import asyncio
+        >>> async def source(name: str, delay: float, ok: bool) -> Result[str, str]:
+        ...     await asyncio.sleep(delay)
+        ...     return Ok(name) if ok else Err(f"{name} failed")
+
+        A fast ``Err`` does not end the race — the slower ``Ok`` still wins:
+
+        >>> asyncio.run(
+        ...     first_ok(
+        ...         [
+        ...             source("mirror", 0.0, ok=False),
+        ...             source("primary", 0.01, ok=True),
+        ...         ],
+        ...     ),
+        ... )
+        Ok('primary')
+
+        When every alternative fails, the errors arrive in input order,
+        regardless of completion order:
+
+        >>> asyncio.run(
+        ...     first_ok(
+        ...         [
+        ...             source("primary", 0.01, ok=False),
+        ...             source("mirror", 0.0, ok=False),
+        ...         ],
+        ...     ),
+        ... )
+        Err(['primary failed', 'mirror failed'])
+
+    """
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
+    indexed: dict[int, E] = {}
+
+    try:
+        next_idx = await _fill_indexed(pending, src, concurrency)
+        while pending:
+            done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+            batch, excs = _split_done(done)
+            if excs:
+                excs.extend(await _drain(pending, src))
+                pending = set()
+                raise BaseExceptionGroup(_GROUP_MSG, excs)
+            batch.sort(key=operator.itemgetter(0))
+            # The race is won by any Ok in the batch — check before recording
+            # errors or refilling, so no item is pulled after the win.
+            for _idx, result in batch:
+                match result:
+                    case Ok():
+                        return result
+                    case Err():
+                        pass
+            for idx, result in batch:
+                match result:
+                    case Err(e):
+                        indexed[idx] = e
+                        next_item = await _pull(src, pending)
+                        if next_item is not None:
+                            pending.add(_wrap_indexed(next_idx, next_item))
+                            next_idx += 1
+                    case Ok():  # pragma: no cover — handled by the loop above
+                        pass
+    finally:
+        await _cancel_all(pending, src)
+
+    return Err([indexed[i] for i in range(len(indexed))])
+
+
 async def filter_ok_unordered(
     iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -296,6 +296,10 @@ async def collect(
 
     Accepts a plain iterable or an async iterable (e.g. an async generator)
     of awaitables — async sources are consumed lazily and closed on exit.
+    An async source keeps listing and processing interleaved: passing an
+    async generator over a paginated API means at most *concurrency* requests
+    are in flight, where materialising it first would crawl every page into
+    memory before the first item is processed.
 
     Results are returned in input order.
     Returns the first ``Err`` encountered, cancelling remaining tasks.
@@ -429,7 +433,12 @@ async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
 
     The heterogeneous sibling of ``collect`` and the async counterpart of
     ``Result.zip``: each awaitable may produce a different ``Ok`` type, and
-    the values are combined into a single tuple.
+    the values are combined into a single tuple. Use it to assemble one
+    response out of several unrelated calls — the case ``collect`` cannot
+    cover, since it needs a homogeneous list. Unlike ``asyncio.gather``, the
+    values stay typed instead of collapsing into ``list[Any]``, and an
+    expected failure stays a value instead of an exception to be told apart
+    from a bug.
 
     Values are returned in argument order, regardless of completion order.
     Returns the first ``Err`` to complete, cancelling the remaining awaitables;
@@ -445,20 +454,24 @@ async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
     on timing. Handle with ``except*``.
 
     Examples:
+        A checkout page needs a profile, a balance and a shipping quote —
+        three types, three upstreams, one round of latency:
+
         >>> import asyncio
-        >>> async def fetch_name() -> Result[str, str]:
+        >>> async def load_profile() -> Result[str, str]:
         ...     return Ok("alice")
-        >>> async def fetch_age() -> Result[int, str]:
-        ...     return Ok(30)
-        >>> asyncio.run(zip(fetch_name(), fetch_age()))
-        Ok(('alice', 30))
+        >>> async def load_balance() -> Result[int, str]:
+        ...     return Ok(2500)
+        >>> asyncio.run(zip(load_profile(), load_balance()))
+        Ok(('alice', 2500))
 
-        The first ``Err`` to complete wins and the rest are cancelled:
+        The first ``Err`` to complete wins and the rest are cancelled, so a
+        checkout that already failed stops charging the other upstreams:
 
-        >>> async def broken() -> Result[int, str]:
-        ...     return Err("bad")
-        >>> asyncio.run(zip(fetch_name(), broken()))
-        Err('bad')
+        >>> async def load_balance_declined() -> Result[int, str]:
+        ...     return Err("card declined")
+        >>> asyncio.run(zip(load_profile(), load_balance_declined()))
+        Err('card declined')
 
     """
     collected = await collect(results)
@@ -665,8 +678,11 @@ async def first_ok(
     Race coroutines or tasks concurrently, returning the first ``Ok`` to complete.
 
     The dual of ``collect``: ``collect`` is all values or the first error,
-    ``first_ok`` is the first value or all errors. Use it to try alternative
-    sources concurrently and take whichever succeeds first.
+    ``first_ok`` is the first value or all errors. Use it when the same thing
+    can be fetched from several places — mirrors, replicas, cache tiers:
+    ask all of them at once and pay the fastest one's latency instead of the
+    preferred one's. The cost of the extra attempts is bounded, since the
+    losers are cancelled rather than left running.
 
     Accepts a plain iterable or an async iterable (e.g. an async generator)
     of awaitables — async sources are consumed lazily and closed on exit.
@@ -695,34 +711,35 @@ async def first_ok(
 
     Examples:
         >>> import asyncio
-        >>> async def source(name: str, delay: float, ok: bool) -> Result[str, str]:
-        ...     await asyncio.sleep(delay)
-        ...     return Ok(name) if ok else Err(f"{name} failed")
+        >>> async def download(host: str, latency: float, has_file: bool) -> Result[str, str]:
+        ...     await asyncio.sleep(latency)
+        ...     return Ok(f"app.tar from {host}") if has_file else Err(f"{host}: 404")
 
-        A fast ``Err`` does not end the race — the slower ``Ok`` still wins:
+        A fast ``Err`` does not end the race — a mirror that answers "404"
+        first must not beat the mirror that has the file:
 
         >>> asyncio.run(
         ...     first_ok(
         ...         [
-        ...             source("mirror", 0.0, ok=False),
-        ...             source("primary", 0.01, ok=True),
+        ...             download("ap.cdn", 0.0, has_file=False),
+        ...             download("us.cdn", 0.01, has_file=True),
         ...         ],
         ...     ),
         ... )
-        Ok('primary')
+        Ok('app.tar from us.cdn')
 
         When every alternative fails, the errors arrive in input order,
-        regardless of completion order:
+        regardless of completion order — the log says which mirror said what:
 
         >>> asyncio.run(
         ...     first_ok(
         ...         [
-        ...             source("primary", 0.01, ok=False),
-        ...             source("mirror", 0.0, ok=False),
+        ...             download("us.cdn", 0.01, has_file=False),
+        ...             download("ap.cdn", 0.0, has_file=False),
         ...         ],
         ...     ),
         ... )
-        Err(['primary failed', 'mirror failed'])
+        Err(['us.cdn: 404', 'ap.cdn: 404'])
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -12,7 +12,8 @@ from collections.abc import (
     Iterable,
     Iterator,
 )
-from typing import Any, Generic, TypeVar, overload
+from functools import partial
+from typing import Any, Generic, NoReturn, TypeVar, overload
 
 from .result import Err, Ok, Result
 
@@ -34,49 +35,71 @@ _CoroOrTask = Coroutine[object, object, _R] | asyncio.Task[_R]
 _GROUP_MSG = "one or more awaitables raised exceptions"
 
 
+def _finalize_item(item: _CoroOrTask[_R]) -> BaseException | None:
+    """
+    Cancel *item* if it is a task, close it if it is an unstarted coroutine.
+
+    A raising teardown is returned rather than raised so each caller decides
+    its fate: ``_Source.aclose`` collects it into the propagating group,
+    while ``_wrap_indexed``'s done-callback re-raises it to the event loop's
+    exception handler.
+    """
+    try:
+        if isinstance(item, asyncio.Task):
+            item.cancel()
+        else:
+            item.close()
+    except BaseException as exc:  # noqa: BLE001 — the caller decides how to surface it
+        return exc
+    return None
+
+
 class _Source(Generic[_R]):
     """
     Uniform lazy pull interface over a sync or async source of awaitables.
+
+    Sync-vs-async is resolved once, at construction: for a sync source
+    ``sync_next`` is a plain callable that pulls without awaiting — the hot
+    paths call it directly, paying neither an ``isinstance`` check nor a
+    coroutine frame per item — while for an async source it is ``None`` and
+    items come from ``next_item``.
 
     ``aclose`` finalizes whatever the source still holds: unconsumed sync
     items are closed (or cancelled, for tasks) and an async-generator source
     is closed with ``aclose()`` so its finalizers run deterministically.
     """
 
-    _it: Iterator[_CoroOrTask[_R]] | AsyncIterator[_CoroOrTask[_R]]
+    _it: Iterator[_CoroOrTask[_R]]
+    _ait: AsyncIterator[_CoroOrTask[_R]]
+    sync_next: Callable[[], _CoroOrTask[_R] | None] | None
 
     def __init__(
         self,
         iterable: Iterable[_CoroOrTask[_R]] | AsyncIterable[_CoroOrTask[_R]],
     ) -> None:
         if isinstance(iterable, AsyncIterable):
-            self._it = aiter(iterable)
+            self._ait = aiter(iterable)
+            self.sync_next = None
         else:
             self._it = iter(iterable)
+            self.sync_next = partial(next, self._it, None)
 
     async def next_item(self) -> _CoroOrTask[_R] | None:
-        """Pull the next item, or ``None`` once the source is exhausted."""
-        if isinstance(self._it, AsyncIterator):
-            try:
-                return await anext(self._it)
-            except StopAsyncIteration:
-                return None
-        return next(self._it, None)
+        """
+        Pull the next item from an async source, or ``None`` once exhausted.
+
+        Sync sources are served by ``sync_next`` instead, which never awaits.
+        """
+        try:
+            return await anext(self._ait)
+        except StopAsyncIteration:
+            return None
 
     async def aclose(self) -> list[BaseException]:
         """Finalize the source, returning non-cancellation teardown exceptions."""
-        if not isinstance(self._it, AsyncIterator):
-            excs: list[BaseException] = []
-            for item in self._it:
-                try:
-                    if isinstance(item, asyncio.Task):
-                        item.cancel()
-                    else:
-                        item.close()
-                except BaseException as exc:  # noqa: BLE001 — collected by the caller
-                    excs.append(exc)
-            return excs
-        aclose = getattr(self._it, "aclose", None)
+        if self.sync_next is not None:
+            return [exc for item in self._it if (exc := _finalize_item(item)) is not None]
+        aclose = getattr(self._ait, "aclose", None)
         if aclose is None:
             return []
         try:
@@ -119,24 +142,59 @@ async def _cancel_all(
     await _drain(pending, src)
 
 
+async def _fail(
+    exc: BaseException,
+    src: _Source[_R],
+    pending: set[asyncio.Task[_S]],
+) -> NoReturn:
+    """
+    Cancel *pending*, finalize *src*, re-raise *exc* inside an ``ExceptionGroup``.
+
+    A raising source is an infrastructure failure: everything — including any
+    exception raised during the teardown — propagates as a single group, the
+    same contract a raising task follows. Cancellation is not a source
+    failure and passes through bare.
+    """
+    if isinstance(exc, asyncio.CancelledError):
+        raise exc
+    excs = [exc, *await _drain(pending, src)]
+    raise BaseExceptionGroup(_GROUP_MSG, excs) from None
+
+
 async def _pull(
     src: _Source[_R],
     pending: set[asyncio.Task[_S]],
 ) -> _CoroOrTask[_R] | None:
     """
-    Pull the next item from *src*, or ``None`` once it is exhausted.
+    Pull the next item from an async *src*, or ``None`` once it is exhausted.
 
-    A raising source is an infrastructure failure: cancel *pending*, finalize
-    the source, and propagate everything as a single ``ExceptionGroup`` — the
-    same contract a raising task follows.
+    A raising source cancels *pending*, finalizes the source, and propagates
+    everything as a single ``ExceptionGroup`` (see ``_fail``). Sync sources
+    take the non-awaiting ``_pull_sync`` path instead.
     """
     try:
         return await src.next_item()
     except asyncio.CancelledError:
         raise
-    except BaseException as exc:  # noqa: BLE001 — re-raised in the group below
-        excs = [exc, *await _drain(pending, src)]
-        raise BaseExceptionGroup(_GROUP_MSG, excs) from None
+    except BaseException as exc:  # noqa: BLE001 — re-raised in the group by _fail
+        return await _fail(exc, src, pending)
+
+
+def _pull_sync(
+    sync_next: Callable[[], _CoroOrTask[_R] | None],
+) -> tuple[_CoroOrTask[_R] | None, BaseException | None]:
+    """
+    Pull the next item from a sync source without awaiting.
+
+    Returns ``(item, None)`` — ``(None, None)`` once the source is
+    exhausted — or ``(None, exc)`` if the source raised: the caller forwards
+    *exc* to ``_fail``, so a raising sync source keeps ``_pull``'s exception
+    contract without paying a coroutine frame per pull on the happy path.
+    """
+    try:
+        return sync_next(), None
+    except BaseException as exc:  # noqa: BLE001 — forwarded to _fail by the caller
+        return None, exc
 
 
 def _check_concurrency(concurrency: int | None) -> None:
@@ -161,46 +219,44 @@ def _wrap_indexed(idx: int, item: _CoroOrTask[_R]) -> asyncio.Task[tuple[int, _R
         # cancelling the wrapper could not reach it — finalize it directly.
         if entered:
             return
-        if isinstance(item, asyncio.Task):
-            item.cancel()
-        else:
-            item.close()
+        exc = _finalize_item(item)
+        if exc is not None:
+            # A raising teardown propagates out of the done callback to the
+            # event loop's exception handler, exactly as an unguarded call
+            # would — it must not be silently discarded here.
+            raise exc
 
     task.add_done_callback(_finalize)
     return task
 
 
-async def _fill_indexed(
-    pending: set[asyncio.Task[tuple[int, _R]]],
+def _wrap_plain(_idx: int, item: _CoroOrTask[_R]) -> asyncio.Task[_R]:
+    """Schedule *item* as-is, ignoring its index (unordered pipelines)."""
+    return asyncio.ensure_future(item)
+
+
+async def _fill(
+    pending: set[asyncio.Task[_S]],
     src: _Source[_R],
     concurrency: int | None,
+    wrap: Callable[[int, _CoroOrTask[_R]], asyncio.Task[_S]],
 ) -> int:
-    """Schedule the initial window of indexed tasks into *pending*."""
+    """Schedule the initial window of tasks (built by *wrap*) into *pending*; return its size."""
     _check_concurrency(concurrency)
+    sync_next = src.sync_next
     idx = 0
     while concurrency is None or idx < concurrency:
-        item = await _pull(src, pending)
+        if sync_next is None:
+            item = await _pull(src, pending)
+        else:
+            item, exc = _pull_sync(sync_next)
+            if exc is not None:
+                await _fail(exc, src, pending)
         if item is None:
             break
-        pending.add(_wrap_indexed(idx, item))
+        pending.add(wrap(idx, item))
         idx += 1
     return idx
-
-
-async def _fill_unordered(
-    pending: set[asyncio.Task[_R]],
-    src: _Source[_R],
-    concurrency: int | None,
-) -> None:
-    """Schedule the initial window of tasks into *pending*."""
-    _check_concurrency(concurrency)
-    count = 0
-    while concurrency is None or count < concurrency:
-        item = await _pull(src, pending)
-        if item is None:
-            return
-        pending.add(asyncio.ensure_future(item))
-        count += 1
 
 
 def _split_done(done: set[asyncio.Task[_R]]) -> tuple[list[_R], list[BaseException]]:
@@ -292,11 +348,12 @@ async def collect(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     indexed: dict[int, T] = {}
 
     try:
-        next_idx = await _fill_indexed(pending, src, concurrency)
+        next_idx = await _fill(pending, src, concurrency, _wrap_indexed)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
@@ -309,7 +366,12 @@ async def collect(
                 match result:
                     case Ok(value):
                         indexed[idx] = value
-                        next_item = await _pull(src, pending)
+                        if sync_next is None:
+                            next_item = await _pull(src, pending)
+                        else:
+                            next_item, exc = _pull_sync(sync_next)
+                            if exc is not None:
+                                await _fail(exc, src, pending)
                         if next_item is not None:
                             pending.add(_wrap_indexed(next_idx, next_item))
                             next_idx += 1
@@ -475,11 +537,12 @@ async def partition(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     indexed: dict[int, Result[T, E]] = {}
 
     try:
-        next_idx = await _fill_indexed(pending, src, concurrency)
+        next_idx = await _fill(pending, src, concurrency, _wrap_indexed)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
@@ -489,7 +552,12 @@ async def partition(
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 indexed[idx] = result
-                next_item = await _pull(src, pending)
+                if sync_next is None:
+                    next_item = await _pull(src, pending)
+                else:
+                    next_item, exc = _pull_sync(sync_next)
+                    if exc is not None:
+                        await _fail(exc, src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
@@ -658,11 +726,12 @@ async def first_ok(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     indexed: dict[int, E] = {}
 
     try:
-        next_idx = await _fill_indexed(pending, src, concurrency)
+        next_idx = await _fill(pending, src, concurrency, _wrap_indexed)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
@@ -677,18 +746,19 @@ async def first_ok(
                 match result:
                     case Ok():
                         return result
-                    case Err():
-                        pass
             for idx, result in batch:
                 match result:
                     case Err(e):
                         indexed[idx] = e
-                        next_item = await _pull(src, pending)
+                        if sync_next is None:
+                            next_item = await _pull(src, pending)
+                        else:
+                            next_item, exc = _pull_sync(sync_next)
+                            if exc is not None:
+                                await _fail(exc, src, pending)
                         if next_item is not None:
                             pending.add(_wrap_indexed(next_idx, next_item))
                             next_idx += 1
-                    case Ok():  # pragma: no cover — handled by the loop above
-                        pass
     finally:
         await _cancel_all(pending, src)
 
@@ -729,10 +799,11 @@ async def filter_ok_unordered(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[Result[T, E]]] = set()
 
     try:
-        await _fill_unordered(pending, src, concurrency)
+        await _fill(pending, src, concurrency, _wrap_plain)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             results, excs = _split_done(done)
@@ -746,7 +817,12 @@ async def filter_ok_unordered(
                         yield value
                     case Err():
                         pass
-                next_item = await _pull(src, pending)
+                if sync_next is None:
+                    next_item = await _pull(src, pending)
+                else:
+                    next_item, exc = _pull_sync(sync_next)
+                    if exc is not None:
+                        await _fail(exc, src, pending)
                 if next_item is not None:
                     pending.add(asyncio.ensure_future(next_item))
     finally:
@@ -787,10 +863,11 @@ async def filter_err_unordered(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[Result[T, E]]] = set()
 
     try:
-        await _fill_unordered(pending, src, concurrency)
+        await _fill(pending, src, concurrency, _wrap_plain)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             results, excs = _split_done(done)
@@ -804,7 +881,12 @@ async def filter_err_unordered(
                         pass
                     case Err(e):
                         yield e
-                next_item = await _pull(src, pending)
+                if sync_next is None:
+                    next_item = await _pull(src, pending)
+                else:
+                    next_item, exc = _pull_sync(sync_next)
+                    if exc is not None:
+                        await _fail(exc, src, pending)
                 if next_item is not None:
                     pending.add(asyncio.ensure_future(next_item))
     finally:
@@ -847,12 +929,13 @@ async def filter_ok(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     buf: dict[int, Result[T, E]] = {}
     next_yield = 0
 
     try:
-        next_idx = await _fill_indexed(pending, src, concurrency)
+        next_idx = await _fill(pending, src, concurrency, _wrap_indexed)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
@@ -862,7 +945,12 @@ async def filter_ok(
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 buf[idx] = result
-                next_item = await _pull(src, pending)
+                if sync_next is None:
+                    next_item = await _pull(src, pending)
+                else:
+                    next_item, exc = _pull_sync(sync_next)
+                    if exc is not None:
+                        await _fail(exc, src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
@@ -914,12 +1002,13 @@ async def filter_err(
 
     """
     src: _Source[Result[T, E]] = _Source(iterable)
+    sync_next = src.sync_next
     pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     buf: dict[int, Result[T, E]] = {}
     next_yield = 0
 
     try:
-        next_idx = await _fill_indexed(pending, src, concurrency)
+        next_idx = await _fill(pending, src, concurrency, _wrap_indexed)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
@@ -929,7 +1018,12 @@ async def filter_err(
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 buf[idx] = result
-                next_item = await _pull(src, pending)
+                if sync_next is None:
+                    next_item = await _pull(src, pending)
+                else:
+                    next_item, exc = _pull_sync(sync_next)
+                    if exc is not None:
+                        await _fail(exc, src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
@@ -985,10 +1079,11 @@ async def try_reduce(
 
     """
     src: _Source[T] = _Source(iterable)
+    sync_next = src.sync_next
     acc: U = initial
     try:
         while True:
-            item = await src.next_item()
+            item = sync_next() if sync_next is not None else await src.next_item()
             if item is None:
                 break
             value: T = await item

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -66,12 +66,16 @@ class _Source(Generic[_R]):
     async def aclose(self) -> list[BaseException]:
         """Finalize the source, returning non-cancellation teardown exceptions."""
         if not isinstance(self._it, AsyncIterator):
+            excs: list[BaseException] = []
             for item in self._it:
-                if isinstance(item, asyncio.Task):
-                    item.cancel()
-                else:
-                    item.close()
-            return []
+                try:
+                    if isinstance(item, asyncio.Task):
+                        item.cancel()
+                    else:
+                        item.close()
+                except BaseException as exc:  # noqa: BLE001 — collected by the caller
+                    excs.append(exc)
+            return excs
         aclose = getattr(self._it, "aclose", None)
         if aclose is None:
             return []
@@ -135,6 +139,13 @@ async def _pull(
         raise BaseExceptionGroup(_GROUP_MSG, excs) from None
 
 
+def _check_concurrency(concurrency: int | None) -> None:
+    """Reject a concurrency bound that would silently schedule nothing."""
+    if concurrency is not None and concurrency < 1:
+        msg = f"concurrency must be at least 1 or None (unlimited), got {concurrency}"
+        raise ValueError(msg)
+
+
 def _wrap_indexed(idx: int, item: _CoroOrTask[_R]) -> asyncio.Task[tuple[int, _R]]:
     entered = False
 
@@ -165,6 +176,7 @@ async def _fill_indexed(
     concurrency: int | None,
 ) -> int:
     """Schedule the initial window of indexed tasks into *pending*."""
+    _check_concurrency(concurrency)
     idx = 0
     while concurrency is None or idx < concurrency:
         item = await _pull(src, pending)
@@ -181,6 +193,7 @@ async def _fill_unordered(
     concurrency: int | None,
 ) -> None:
     """Schedule the initial window of tasks into *pending*."""
+    _check_concurrency(concurrency)
     count = 0
     while concurrency is None or count < concurrency:
         item = await _pull(src, pending)
@@ -357,7 +370,9 @@ async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
     the values are combined into a single tuple.
 
     Values are returned in argument order, regardless of completion order.
-    Returns the first ``Err`` to complete, cancelling the remaining awaitables.
+    Returns the first ``Err`` to complete, cancelling the remaining awaitables;
+    if several complete in the same event-loop iteration, the earliest by
+    argument order is returned.
 
     All awaitables are scheduled at once — there is no concurrency limit.
 
@@ -588,12 +603,13 @@ async def first_ok(
     Accepts a plain iterable or an async iterable (e.g. an async generator)
     of awaitables — async sources are consumed lazily and closed on exit.
 
-    The first ``Ok`` to complete wins: remaining in-flight tasks are cancelled
-    and unconsumed items are closed — slower alternatives are not awaited once
-    one has succeeded. An early ``Err`` does not end the race: it is recorded
-    and the race continues. If every awaitable completes with ``Err``, returns
-    ``Err`` of every error in input order (not completion order); empty input
-    gives ``Err([])``.
+    The first ``Ok`` to complete wins (if several complete in the same
+    event-loop iteration, the earliest by input order is returned): remaining
+    in-flight tasks are cancelled and unconsumed items are closed — slower
+    alternatives are not awaited once one has succeeded. An early ``Err``
+    does not end the race: it is recorded and the race continues. If every
+    awaitable completes with ``Err``, returns ``Err`` of every error in input
+    order (not completion order); empty input gives ``Err([])``.
 
     *concurrency* limits how many run at the same time.
     ``None`` means unlimited — all are scheduled at once.
@@ -946,6 +962,11 @@ async def try_reduce(
 
     On short-circuit — and on any exception — remaining tasks are cancelled,
     unconsumed coroutines are closed, and an async-generator source is closed.
+    Exceptions raised during that teardown never mask the fold's outcome: a
+    propagating exception stays the exception the caller sees, a normal
+    ``Ok`` / ``Err`` return is still returned, and the teardown exception
+    itself is suppressed — the same policy the concurrent functions apply on
+    their success path.
 
     **Exceptions**: unlike the concurrent functions, execution is sequential —
     only one coroutine can fail — so exceptions propagate bare, without an
@@ -977,7 +998,5 @@ async def try_reduce(
                 case Err() as err:
                     return err
     finally:
-        teardown_excs = await src.aclose()
-        if teardown_excs:
-            raise teardown_excs[0]
+        await src.aclose()
     return Ok(acc)

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -12,13 +12,19 @@ from collections.abc import (
     Iterable,
     Iterator,
 )
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar, overload
 
 from .result import Err, Ok, Result
 
 T = TypeVar("T")
 U = TypeVar("U")
 E = TypeVar("E")
+
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+T3 = TypeVar("T3")
+T4 = TypeVar("T4")
+T5 = TypeVar("T5")
 
 _R = TypeVar("_R")
 _S = TypeVar("_S")
@@ -300,6 +306,86 @@ async def collect(
         await _cancel_all(pending, src)
 
     return Ok([indexed[i] for i in range(len(indexed))])
+
+
+@overload
+async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
+    r1: _CoroOrTask[Result[T1, E]],
+    r2: _CoroOrTask[Result[T2, E]],
+    /,
+) -> Result[tuple[T1, T2], E]: ...
+
+
+@overload
+async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
+    r1: _CoroOrTask[Result[T1, E]],
+    r2: _CoroOrTask[Result[T2, E]],
+    r3: _CoroOrTask[Result[T3, E]],
+    /,
+) -> Result[tuple[T1, T2, T3], E]: ...
+
+
+@overload
+async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
+    r1: _CoroOrTask[Result[T1, E]],
+    r2: _CoroOrTask[Result[T2, E]],
+    r3: _CoroOrTask[Result[T3, E]],
+    r4: _CoroOrTask[Result[T4, E]],
+    /,
+) -> Result[tuple[T1, T2, T3, T4], E]: ...
+
+
+@overload
+async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
+    r1: _CoroOrTask[Result[T1, E]],
+    r2: _CoroOrTask[Result[T2, E]],
+    r3: _CoroOrTask[Result[T3, E]],
+    r4: _CoroOrTask[Result[T4, E]],
+    r5: _CoroOrTask[Result[T5, E]],
+    /,
+) -> Result[tuple[T1, T2, T3, T4, T5], E]: ...
+
+
+async def zip(  # noqa: A001 — intentional builtin shadow, mirrors Result.zip
+    *results: _CoroOrTask[Result[Any, Any]],
+) -> Result[tuple[Any, ...], Any]:
+    """
+    Await two to five coroutines or tasks concurrently, zipping values into ``Ok[tuple]``.
+
+    The heterogeneous sibling of ``collect`` and the async counterpart of
+    ``Result.zip``: each awaitable may produce a different ``Ok`` type, and
+    the values are combined into a single tuple.
+
+    Values are returned in argument order, regardless of completion order.
+    Returns the first ``Err`` to complete, cancelling the remaining awaitables.
+
+    All awaitables are scheduled at once — there is no concurrency limit.
+
+    **Exceptions**: if any coroutine raises, all remaining tasks are cancelled and
+    every exception — including any raised while those tasks were being cancelled —
+    propagates as a single ``ExceptionGroup``, even when only one task failed.
+    One failure is a group of one: the exception type you catch never depends
+    on timing. Handle with ``except*``.
+
+    Examples:
+        >>> import asyncio
+        >>> async def fetch_name() -> Result[str, str]:
+        ...     return Ok("alice")
+        >>> async def fetch_age() -> Result[int, str]:
+        ...     return Ok(30)
+        >>> asyncio.run(zip(fetch_name(), fetch_age()))
+        Ok(('alice', 30))
+
+        The first ``Err`` to complete wins and the rest are cancelled:
+
+        >>> async def broken() -> Result[int, str]:
+        ...     return Err("bad")
+        >>> asyncio.run(zip(fetch_name(), broken()))
+        Err('bad')
+
+    """
+    collected = await collect(results)
+    return collected.map(tuple)
 
 
 async def map_collect(

--- a/src/corrode/async_iterator.py
+++ b/src/corrode/async_iterator.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import asyncio
-import itertools
 import operator
-from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Iterator
-from typing import TypeVar
+from collections.abc import (
+    AsyncIterable,
+    AsyncIterator,
+    Callable,
+    Coroutine,
+    Iterable,
+    Iterator,
+)
+from typing import Generic, TypeVar
 
 from .result import Err, Ok, Result
 
@@ -22,56 +28,160 @@ _CoroOrTask = Coroutine[object, object, _R] | asyncio.Task[_R]
 _GROUP_MSG = "one or more awaitables raised exceptions"
 
 
+class _Source(Generic[_R]):
+    """
+    Uniform lazy pull interface over a sync or async source of awaitables.
+
+    ``aclose`` finalizes whatever the source still holds: unconsumed sync
+    items are closed (or cancelled, for tasks) and an async-generator source
+    is closed with ``aclose()`` so its finalizers run deterministically.
+    """
+
+    _it: Iterator[_CoroOrTask[_R]] | AsyncIterator[_CoroOrTask[_R]]
+
+    def __init__(
+        self,
+        iterable: Iterable[_CoroOrTask[_R]] | AsyncIterable[_CoroOrTask[_R]],
+    ) -> None:
+        if isinstance(iterable, AsyncIterable):
+            self._it = aiter(iterable)
+        else:
+            self._it = iter(iterable)
+
+    async def next_item(self) -> _CoroOrTask[_R] | None:
+        """Pull the next item, or ``None`` once the source is exhausted."""
+        if isinstance(self._it, AsyncIterator):
+            try:
+                return await anext(self._it)
+            except StopAsyncIteration:
+                return None
+        return next(self._it, None)
+
+    async def aclose(self) -> list[BaseException]:
+        """Finalize the source, returning non-cancellation teardown exceptions."""
+        if not isinstance(self._it, AsyncIterator):
+            for item in self._it:
+                if isinstance(item, asyncio.Task):
+                    item.cancel()
+                else:
+                    item.close()
+            return []
+        aclose = getattr(self._it, "aclose", None)
+        if aclose is None:
+            return []
+        try:
+            await aclose()
+        except asyncio.CancelledError:
+            raise
+        except BaseException as exc:  # noqa: BLE001 — collected into the propagating group
+            return [exc]
+        return []
+
+
 async def _drain(
     pending: set[asyncio.Task[_R]],
-    it: Iterator[_CoroOrTask[_S]],
+    src: _Source[_S],
 ) -> list[BaseException]:
     """
-    Cancel *pending*, close unconsumed items, collect teardown exceptions.
+    Cancel *pending*, finalize *src*, collect teardown exceptions.
 
     Tasks that raise something other than ``CancelledError`` while being
-    cancelled would otherwise be silently discarded; return those exceptions
-    so the caller can attach them to the propagating ``ExceptionGroup``.
+    cancelled — and a source whose ``aclose()`` raises — would otherwise be
+    silently discarded; return those exceptions so the caller can attach
+    them to the propagating ``ExceptionGroup``.
     """
     for t in pending:
         t.cancel()
     results = await asyncio.gather(*pending, return_exceptions=True)
-    for item in it:
-        if isinstance(item, asyncio.Task):
-            item.cancel()
-        else:
-            item.close()
-    return [
+    excs = [
         r
         for r in results
         if isinstance(r, BaseException) and not isinstance(r, asyncio.CancelledError)
     ]
+    excs.extend(await src.aclose())
+    return excs
 
 
 async def _cancel_all(
     pending: set[asyncio.Task[_R]],
-    it: Iterator[_CoroOrTask[_S]],
+    src: _Source[_S],
 ) -> None:
-    await _drain(pending, it)
+    await _drain(pending, src)
+
+
+async def _pull(
+    src: _Source[_R],
+    pending: set[asyncio.Task[_S]],
+) -> _CoroOrTask[_R] | None:
+    """
+    Pull the next item from *src*, or ``None`` once it is exhausted.
+
+    A raising source is an infrastructure failure: cancel *pending*, finalize
+    the source, and propagate everything as a single ``ExceptionGroup`` — the
+    same contract a raising task follows.
+    """
+    try:
+        return await src.next_item()
+    except asyncio.CancelledError:
+        raise
+    except BaseException as exc:  # noqa: BLE001 — re-raised in the group below
+        excs = [exc, *await _drain(pending, src)]
+        raise BaseExceptionGroup(_GROUP_MSG, excs) from None
 
 
 def _wrap_indexed(idx: int, item: _CoroOrTask[_R]) -> asyncio.Task[tuple[int, _R]]:
+    entered = False
+
     async def _inner() -> tuple[int, _R]:
+        nonlocal entered
+        entered = True
         return idx, await item
 
-    return asyncio.ensure_future(_inner())
+    task = asyncio.ensure_future(_inner())
+
+    def _finalize(_task: asyncio.Task[tuple[int, _R]]) -> None:
+        # Cancelled before the wrapper ever ran: *item* was never started, so
+        # cancelling the wrapper could not reach it — finalize it directly.
+        if entered:
+            return
+        if isinstance(item, asyncio.Task):
+            item.cancel()
+        else:
+            item.close()
+
+    task.add_done_callback(_finalize)
+    return task
 
 
-def _make_pending_indexed(
-    it: Iterator[_CoroOrTask[_R]],
+async def _fill_indexed(
+    pending: set[asyncio.Task[tuple[int, _R]]],
+    src: _Source[_R],
     concurrency: int | None,
-) -> tuple[set[asyncio.Task[tuple[int, _R]]], int]:
-    pending: set[asyncio.Task[tuple[int, _R]]] = set()
+) -> int:
+    """Schedule the initial window of indexed tasks into *pending*."""
     idx = 0
-    for item in it if concurrency is None else itertools.islice(it, concurrency):
+    while concurrency is None or idx < concurrency:
+        item = await _pull(src, pending)
+        if item is None:
+            break
         pending.add(_wrap_indexed(idx, item))
         idx += 1
-    return pending, idx
+    return idx
+
+
+async def _fill_unordered(
+    pending: set[asyncio.Task[_R]],
+    src: _Source[_R],
+    concurrency: int | None,
+) -> None:
+    """Schedule the initial window of tasks into *pending*."""
+    count = 0
+    while concurrency is None or count < concurrency:
+        item = await _pull(src, pending)
+        if item is None:
+            return
+        pending.add(asyncio.ensure_future(item))
+        count += 1
 
 
 def _split_done(done: set[asyncio.Task[_R]]) -> tuple[list[_R], list[BaseException]]:
@@ -86,13 +196,31 @@ def _split_done(done: set[asyncio.Task[_R]]) -> tuple[list[_R], list[BaseExcepti
     return values, excs
 
 
+async def _map_source(
+    iterable: AsyncIterable[T],
+    f: Callable[[T], _CoroOrTask[_R]],
+) -> AsyncIterator[_CoroOrTask[_R]]:
+    """Lazily apply *f* over an async source, closing the source on early exit."""
+    it = aiter(iterable)
+    try:
+        async for element in it:
+            yield f(element)
+    finally:
+        aclose = getattr(it, "aclose", None)
+        if aclose is not None:
+            await aclose()
+
+
 async def collect(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int | None = None,
 ) -> Result[list[T], E]:
     """
     Await an iterable of coroutines or tasks concurrently, collecting results into ``Ok[list]``.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     Results are returned in input order.
     Returns the first ``Err`` encountered, cancelling remaining tasks.
@@ -105,6 +233,8 @@ async def collect(
     propagates as a single ``ExceptionGroup``, even when only one task failed.
     One failure is a group of one: the exception type you catch never depends
     on timing. Handle with ``except*``.
+    A raising source follows the same contract: in-flight tasks are cancelled
+    and the source's exception joins the group.
 
     Examples:
         >>> import asyncio
@@ -114,6 +244,15 @@ async def collect(
         Ok([1, 2, 3])
         >>> asyncio.run(collect([fetch(1), fetch(0)], concurrency=4))
         Err('bad')
+
+        An async generator works as a source too — items are pulled lazily
+        as slots free up:
+
+        >>> async def stream():
+        ...     for i in (1, 2, 3):
+        ...         yield fetch(i)
+        >>> asyncio.run(collect(stream(), concurrency=2))
+        Ok([1, 2, 3])
 
         Raised exceptions always arrive as an ``ExceptionGroup`` — one failure
         is a group of one, several failures are collected together:
@@ -133,16 +272,17 @@ async def collect(
         ['eu', 'us']
 
     """
-    it = iter(iterable)
-    pending, next_idx = _make_pending_indexed(it, concurrency)
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     indexed: dict[int, T] = {}
 
     try:
+        next_idx = await _fill_indexed(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             batch.sort(key=operator.itemgetter(0))
@@ -150,26 +290,29 @@ async def collect(
                 match result:
                     case Ok(value):
                         indexed[idx] = value
-                        next_item = next(it, None)
+                        next_item = await _pull(src, pending)
                         if next_item is not None:
                             pending.add(_wrap_indexed(next_idx, next_item))
                             next_idx += 1
                     case Err() as err:
                         return err
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
     return Ok([indexed[i] for i in range(len(indexed))])
 
 
 async def map_collect(
-    iterable: Iterable[T],
+    iterable: Iterable[T] | AsyncIterable[T],
     f: Callable[[T], _CoroOrTask[Result[U, E]]],
     *,
     concurrency: int | None = None,
 ) -> Result[list[U], E]:
     """
     Apply *f* to each element concurrently and collect into ``Ok[list]``.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of elements — async sources are consumed lazily and closed on exit.
 
     Results are returned in input order.
     Returns the first ``Err`` produced by *f*, cancelling remaining tasks.
@@ -191,6 +334,8 @@ async def map_collect(
         Ok([2, 4, 6])
 
     """
+    if isinstance(iterable, AsyncIterable):
+        return await collect(_map_source(iterable, f), concurrency=concurrency)
     return await collect(
         (f(element) for element in iterable),
         concurrency=concurrency,
@@ -198,12 +343,15 @@ async def map_collect(
 
 
 async def partition(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int | None = None,
 ) -> tuple[list[T], list[E]]:
     """
     Await an iterable of coroutines or tasks concurrently, splitting results into ``(oks, errs)``.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     Results are collected in input order within each list.
     Unlike ``collect``, never short-circuits — all awaitables run to completion.
@@ -225,26 +373,27 @@ async def partition(
         ([1, 2], ['bad: -1'])
 
     """
-    it = iter(iterable)
-    pending, next_idx = _make_pending_indexed(it, concurrency)
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     indexed: dict[int, Result[T, E]] = {}
 
     try:
+        next_idx = await _fill_indexed(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 indexed[idx] = result
-                next_item = next(it, None)
+                next_item = await _pull(src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
     oks: list[T] = []
     errs: list[E] = []
@@ -258,13 +407,16 @@ async def partition(
 
 
 async def map_partition(
-    iterable: Iterable[T],
+    iterable: Iterable[T] | AsyncIterable[T],
     f: Callable[[T], _CoroOrTask[Result[U, E]]],
     *,
     concurrency: int | None = None,
 ) -> tuple[list[U], list[E]]:
     """
     Apply *f* to each element concurrently and split the results into ``(oks, errs)``.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of elements — async sources are consumed lazily and closed on exit.
 
     Results are collected in input order within each list.
     Never short-circuits — all calls run to completion.
@@ -286,6 +438,8 @@ async def map_partition(
         ([1, 2], ['bad: -1'])
 
     """
+    if isinstance(iterable, AsyncIterable):
+        return await partition(_map_source(iterable, f), concurrency=concurrency)
     return await partition(
         (f(element) for element in iterable),
         concurrency=concurrency,
@@ -293,12 +447,15 @@ async def map_partition(
 
 
 async def collect_all(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int | None = None,
 ) -> Result[list[T], list[E]]:
     """
     Await coroutines or tasks concurrently, accumulating **all** errors.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     Returns ``Ok`` of all success values (in input order) only if every result
     is ``Ok``; otherwise returns ``Err`` of every error (in input order).
@@ -331,12 +488,15 @@ async def collect_all(
 
 
 async def filter_ok_unordered(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int | None = None,
 ) -> AsyncIterator[T]:
     """
     Await coroutines or tasks concurrently, yielding ``Ok`` values as they complete.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     ``Err`` values are silently skipped.
     Values are yielded in completion order, not input order.
@@ -360,18 +520,16 @@ async def filter_ok_unordered(
         ```
 
     """
-    it = iter(iterable)
-    pending: set[asyncio.Task[Result[T, E]]] = {
-        asyncio.ensure_future(item)
-        for item in (it if concurrency is None else itertools.islice(it, concurrency))
-    }
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[Result[T, E]]] = set()
 
     try:
+        await _fill_unordered(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             results, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for result in results:
@@ -380,20 +538,23 @@ async def filter_ok_unordered(
                         yield value
                     case Err():
                         pass
-                next_item = next(it, None)
+                next_item = await _pull(src, pending)
                 if next_item is not None:
                     pending.add(asyncio.ensure_future(next_item))
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
 
 async def filter_err_unordered(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int | None = None,
 ) -> AsyncIterator[E]:
     """
     Await coroutines or tasks concurrently, yielding ``Err`` values as they complete.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     ``Ok`` values are silently skipped.
     Values are yielded in completion order, not input order.
@@ -417,18 +578,16 @@ async def filter_err_unordered(
         ```
 
     """
-    it = iter(iterable)
-    pending: set[asyncio.Task[Result[T, E]]] = {
-        asyncio.ensure_future(item)
-        for item in (it if concurrency is None else itertools.islice(it, concurrency))
-    }
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[Result[T, E]]] = set()
 
     try:
+        await _fill_unordered(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             results, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for result in results:
@@ -437,20 +596,23 @@ async def filter_err_unordered(
                         pass
                     case Err(e):
                         yield e
-                next_item = next(it, None)
+                next_item = await _pull(src, pending)
                 if next_item is not None:
                     pending.add(asyncio.ensure_future(next_item))
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
 
 async def filter_ok(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int,
 ) -> AsyncIterator[T]:
     """
     Await coroutines or tasks concurrently, yielding ``Ok`` values in input order.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     ``Err`` values are silently skipped.
     Values are yielded in input order — later-completing tasks are buffered until
@@ -476,22 +638,23 @@ async def filter_ok(
         ```
 
     """
-    it = iter(iterable)
-    pending, next_idx = _make_pending_indexed(it, concurrency)
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     buf: dict[int, Result[T, E]] = {}
     next_yield = 0
 
     try:
+        next_idx = await _fill_indexed(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 buf[idx] = result
-                next_item = next(it, None)
+                next_item = await _pull(src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
@@ -504,16 +667,19 @@ async def filter_ok(
                         pass
                 next_yield += 1
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
 
 async def filter_err(
-    iterable: Iterable[_CoroOrTask[Result[T, E]]],
+    iterable: Iterable[_CoroOrTask[Result[T, E]]] | AsyncIterable[_CoroOrTask[Result[T, E]]],
     *,
     concurrency: int,
 ) -> AsyncIterator[E]:
     """
     Await coroutines or tasks concurrently, yielding ``Err`` values in input order.
+
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
 
     ``Ok`` values are silently skipped.
     Values are yielded in input order — later-completing tasks are buffered until
@@ -539,22 +705,23 @@ async def filter_err(
         ```
 
     """
-    it = iter(iterable)
-    pending, next_idx = _make_pending_indexed(it, concurrency)
+    src: _Source[Result[T, E]] = _Source(iterable)
+    pending: set[asyncio.Task[tuple[int, Result[T, E]]]] = set()
     buf: dict[int, Result[T, E]] = {}
     next_yield = 0
 
     try:
+        next_idx = await _fill_indexed(pending, src, concurrency)
         while pending:
             done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
             batch, excs = _split_done(done)
             if excs:
-                excs.extend(await _drain(pending, it))
+                excs.extend(await _drain(pending, src))
                 pending = set()
                 raise BaseExceptionGroup(_GROUP_MSG, excs)
             for idx, result in batch:
                 buf[idx] = result
-                next_item = next(it, None)
+                next_item = await _pull(src, pending)
                 if next_item is not None:
                     pending.add(_wrap_indexed(next_idx, next_item))
                     next_idx += 1
@@ -567,23 +734,26 @@ async def filter_err(
                         yield e
                 next_yield += 1
     finally:
-        await _cancel_all(pending, it)
+        await _cancel_all(pending, src)
 
 
 async def try_reduce(
-    iterable: Iterable[_CoroOrTask[T]],
+    iterable: Iterable[_CoroOrTask[T]] | AsyncIterable[_CoroOrTask[T]],
     initial: U,
     f: Callable[[U, T], Result[U, E]],
 ) -> Result[U, E]:
     """
     Await each coroutine or task sequentially, folding with *f* and short-circuiting on ``Err``.
 
+    Accepts a plain iterable or an async iterable (e.g. an async generator)
+    of awaitables — async sources are consumed lazily and closed on exit.
+
     Unlike the async ``collect`` / ``partition`` family, tasks run one at a time —
     each awaited value is passed to *f* before the next is awaited, because the
     accumulator depends on the previous step.
 
-    On short-circuit — and on any exception — remaining tasks are cancelled and
-    unconsumed coroutines are closed.
+    On short-circuit — and on any exception — remaining tasks are cancelled,
+    unconsumed coroutines are closed, and an async-generator source is closed.
 
     **Exceptions**: unlike the concurrent functions, execution is sequential —
     only one coroutine can fail — so exceptions propagate bare, without an
@@ -601,10 +771,13 @@ async def try_reduce(
         Err('negative: -1')
 
     """
-    it = iter(iterable)
+    src: _Source[T] = _Source(iterable)
     acc: U = initial
     try:
-        for item in it:
+        while True:
+            item = await src.next_item()
+            if item is None:
+                break
             value: T = await item
             match f(acc, value):
                 case Ok(new_acc):
@@ -612,9 +785,7 @@ async def try_reduce(
                 case Err() as err:
                     return err
     finally:
-        for remaining in it:
-            if isinstance(remaining, asyncio.Task):
-                remaining.cancel()
-            else:
-                remaining.close()
+        teardown_excs = await src.aclose()
+        if teardown_excs:
+            raise teardown_excs[0]
     return Ok(acc)

--- a/src/corrode/iterator.py
+++ b/src/corrode/iterator.py
@@ -65,19 +65,37 @@ def first_ok(iterable: Iterable[Result[T, E]]) -> Result[T, list[E]]:
     Return the first ``Ok`` encountered, short-circuiting the iteration.
 
     The dual of ``collect``: ``collect`` is all values or the first error,
-    ``first_ok`` is the first value or all errors. Use it to try alternative
-    sources until one succeeds.
+    ``first_ok`` is the first value or all errors. Use it for a fallback
+    chain — several ways to obtain the same thing, tried in order of
+    preference: config sources, payload schema versions, cache tiers.
 
     Iteration stops at the first ``Ok``, so later elements of a generator are
     never produced — this matters when producing a ``Result`` is expensive.
-    If no ``Ok`` is found, returns ``Err`` of every error in input order;
-    an empty iterable gives ``Err([])``.
+    If no ``Ok`` is found, returns ``Err`` of every error in input order,
+    so a total failure can be reported with every reason at once instead of
+    only the last one; an empty iterable gives ``Err([])``.
 
     Examples:
-        >>> first_ok([Err("a"), Ok(2), Ok(3)])
-        Ok(2)
-        >>> first_ok([Err("a"), Err("b")])
-        Err(['a', 'b'])
+        Accept two payload versions during a producer rollout, without
+        making the caller guess which one arrived:
+
+        >>> def parse_v2(raw: dict[str, object]) -> Result[int, str]:
+        ...     match raw:
+        ...         case {"amount_cents": int(cents)}:
+        ...             return Ok(cents)
+        ...     return Err("v2: no amount_cents")
+        >>> def parse_v1(raw: dict[str, object]) -> Result[int, str]:
+        ...     match raw:
+        ...         case {"amount": str(amount)}:
+        ...             return Ok(round(float(amount) * 100))
+        ...     return Err("v1: no amount")
+        >>> first_ok(parse({"amount": "9.90"}) for parse in (parse_v2, parse_v1))
+        Ok(990)
+
+        Nothing matched — every rejection is reported:
+
+        >>> first_ok(parse({"total": 990}) for parse in (parse_v2, parse_v1))
+        Err(['v2: no amount_cents', 'v1: no amount'])
         >>> first_ok([])
         Err([])
 

--- a/src/corrode/iterator.py
+++ b/src/corrode/iterator.py
@@ -60,6 +60,38 @@ def collect_all(iterable: Iterable[Result[T, E]]) -> Result[list[T], list[E]]:
     return Ok(oks)
 
 
+def first_ok(iterable: Iterable[Result[T, E]]) -> Result[T, list[E]]:
+    """
+    Return the first ``Ok`` encountered, short-circuiting the iteration.
+
+    The dual of ``collect``: ``collect`` is all values or the first error,
+    ``first_ok`` is the first value or all errors. Use it to try alternative
+    sources until one succeeds.
+
+    Iteration stops at the first ``Ok``, so later elements of a generator are
+    never produced — this matters when producing a ``Result`` is expensive.
+    If no ``Ok`` is found, returns ``Err`` of every error in input order;
+    an empty iterable gives ``Err([])``.
+
+    Examples:
+        >>> first_ok([Err("a"), Ok(2), Ok(3)])
+        Ok(2)
+        >>> first_ok([Err("a"), Err("b")])
+        Err(['a', 'b'])
+        >>> first_ok([])
+        Err([])
+
+    """
+    errs: list[E] = []
+    for result in iterable:
+        match result:
+            case Ok():
+                return result
+            case Err(e):
+                errs.append(e)
+    return Err(errs)
+
+
 def map_collect(
     iterable: Iterable[T],
     f: Callable[[T], Result[U, E]],

--- a/src/corrode/result.py
+++ b/src/corrode/result.py
@@ -549,6 +549,25 @@ class Ok(Generic[T_co]):
         """
         return self._value
 
+    def transpose(self: Ok[U | None]) -> Ok[U] | None:
+        """
+        Transpose a ``Result`` of an optional value into an optional ``Result``.
+
+        Convert ``Result[U | None, E]`` into ``Result[U, E] | None``:
+        ``None`` if the contained value is ``None``, the ``Ok`` unchanged
+        otherwise. This is the inverse of ``from_optional``.
+
+        Examples:
+            >>> Ok(1).transpose()
+            Ok(1)
+            >>> Ok(None).transpose() is None
+            True
+
+        """
+        if self._value is None:
+            return None
+        return cast("Ok[U]", self)
+
 
 class DoError(Exception):
     """
@@ -1050,6 +1069,19 @@ class Err(Generic[E_co]):
 
         Examples:
             >>> Err("bad").flatten()
+            Err('bad')
+
+        """
+        return self
+
+    def transpose(self) -> Err[E_co]:
+        """
+        Transpose a ``Result`` of an optional value into an optional ``Result``.
+
+        Since this is an ``Err``, there is no value to inspect — ``self`` is returned.
+
+        Examples:
+            >>> Err("bad").transpose()
             Err('bad')
 
         """

--- a/src/corrode/result.py
+++ b/src/corrode/result.py
@@ -67,7 +67,11 @@ class Ok(Generic[T_co]):
         msg = "Ok is immutable"
         raise AttributeError(msg)
 
-    def __reduce__(self) -> tuple[Callable[[T_co], Ok[T_co]], tuple[T_co]]:
+    # ty: covariant T_co in the constructor callable is safe: pickle only ever
+    # round-trips the instance's own value, never substitutes a supertype.
+    def __reduce__(
+        self,
+    ) -> tuple[Callable[[T_co], Ok[T_co]], tuple[T_co]]:  # ty: ignore[invalid-generic-class]
         return (Ok, (self._value,))
 
     def __repr__(self) -> str:
@@ -624,7 +628,11 @@ class Err(Generic[E_co]):
         msg = "Err is immutable"
         raise AttributeError(msg)
 
-    def __reduce__(self) -> tuple[Callable[[E_co], Err[E_co]], tuple[E_co]]:
+    # ty: covariant E_co in the constructor callable is safe: pickle only ever
+    # round-trips the instance's own value, never substitutes a supertype.
+    def __reduce__(
+        self,
+    ) -> tuple[Callable[[E_co], Err[E_co]], tuple[E_co]]:  # ty: ignore[invalid-generic-class]
         return (Err, (self._value,))
 
     def __repr__(self) -> str:

--- a/src/corrode/result.py
+++ b/src/corrode/result.py
@@ -561,6 +561,11 @@ class Ok(Generic[T_co]):
         ``None`` if the contained value is ``None``, the ``Ok`` unchanged
         otherwise. This is the inverse of ``from_optional``.
 
+        Use it for a lookup that can both fail and legitimately find nothing:
+        moving the "nothing" out of the ``Result`` keeps "no such row" a
+        branch of its own instead of an ``Ok(None)`` that every caller
+        downstream has to remember to check.
+
         Examples:
             >>> Ok(1).transpose()
             Ok(1)

--- a/tests/test_async_iterator.py
+++ b/tests/test_async_iterator.py
@@ -261,6 +261,31 @@ class TestConcurrencyN:
         assert all(v <= 2 for v in started)
 
 
+class TestConcurrencyValidation:
+    async def test_collect_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="concurrency must be at least 1"):
+            await collect([ok_after(1)], concurrency=0)
+
+    async def test_first_ok_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="concurrency must be at least 1"):
+            await first_ok([ok_after(1)], concurrency=0)
+
+    async def test_negative_raises_with_value_in_message(self) -> None:
+        with pytest.raises(ValueError, match="got -3"):
+            await collect([ok_after(1)], concurrency=-3)
+
+    async def test_filter_ok_unordered_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="concurrency must be at least 1"):
+            async for _ in filter_ok_unordered([ok_after(1)], concurrency=0):
+                pass
+
+    async def test_collect_concurrency_one_still_works(self) -> None:
+        assert await collect([ok_after(1), ok_after(2)], concurrency=1) == Ok([1, 2])
+
+    async def test_first_ok_concurrency_one_still_works(self) -> None:
+        assert await first_ok([err_after("nope"), ok_after(1)], concurrency=1) == Ok(1)
+
+
 # ---------------------------------------------------------------------------
 # Order guarantee
 # ---------------------------------------------------------------------------
@@ -390,6 +415,34 @@ class TestExceptionPropagation:
 
         names = sorted(type(e).__name__ for e in exc_info.value.exceptions)
         assert names == ["RuntimeError", "ValueError"]
+
+    async def test_sync_source_close_exception_joins_group_and_drain_continues(self) -> None:
+        # a coroutine whose close() raises mid-drain must not stop the drain:
+        # the close exception joins the group and later items are still closed
+        closed: list[int] = []
+
+        async def boom() -> Ok[int]:
+            raise RuntimeError("boom")
+
+        async def tracked(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            finally:
+                closed.append(v)
+                if v == 2:
+                    raise ValueError("close failed")
+
+        unconsumed = [tracked(1), tracked(2), tracked(3)]
+        for coro in unconsumed:
+            coro.send(None)  # start each one so its finally runs on close()
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await collect([boom(), *unconsumed], concurrency=1)
+
+        assert exc_info.group_contains(RuntimeError, match="boom")
+        assert exc_info.group_contains(ValueError, match="close failed")
+        assert closed == [1, 2, 3]
 
     async def test_cancelling_collect_cancels_children(self) -> None:
         # cancelling the caller's task must not leak the inner tasks
@@ -1337,6 +1390,40 @@ class TestTryReduce:
         result = await try_reduce([int_after(1), remaining], 0, fail)
         assert result == Err("nope: 1")
         assert inspect.getcoroutinestate(remaining) == "CORO_CLOSED"
+
+    async def test_source_teardown_exception_does_not_mask_primary_exception(self) -> None:
+        # the awaited item raises ValueError, then closing the source raises
+        # RuntimeError — the caller must still see the ValueError, bare
+        async def boom() -> int:
+            raise ValueError("primary")
+
+        async def source() -> AsyncIterator[IntCoro]:
+            try:
+                yield boom()
+            finally:
+                raise RuntimeError("teardown")
+
+        def add(acc: int, x: int) -> Ok[int]:
+            return Ok(acc + x)
+
+        with pytest.raises(ValueError, match="primary"):
+            await try_reduce(source(), 0, add)
+
+    async def test_source_teardown_exception_does_not_mask_err_result(self) -> None:
+        # the fold short-circuits with Err, then closing the source raises —
+        # the Err is still returned and the teardown exception is suppressed
+        def fail(_acc: int, x: int) -> Err[str]:
+            return Err(f"nope: {x}")
+
+        async def source() -> AsyncIterator[IntCoro]:
+            try:
+                yield int_after(1)
+                yield int_after(2)
+            finally:
+                raise RuntimeError("teardown")
+
+        result = await try_reduce(source(), 0, fail)
+        assert result == Err("nope: 1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_iterator.py
+++ b/tests/test_async_iterator.py
@@ -15,6 +15,7 @@ from corrode.async_iterator import (
     filter_err_unordered,
     filter_ok,
     filter_ok_unordered,
+    first_ok,
     map_collect,
     map_partition,
     partition,
@@ -1091,6 +1092,114 @@ class TestCollectAll:
         probe = ConcurrencyProbe()
         await collect_all([probe.track(Ok(i)) for i in range(8)], concurrency=3)
         assert probe.peak <= 3
+
+
+# ---------------------------------------------------------------------------
+# first_ok
+# ---------------------------------------------------------------------------
+
+
+class TestFirstOk:
+    async def test_empty(self) -> None:
+        assert await first_ok([]) == Err([])
+
+    async def test_first_ok_to_complete_wins(self) -> None:
+        # completion order is inverted: the slow first element loses the race
+        result = await first_ok([ok_after(1, delay=0.1), ok_after(2, delay=0.0)])
+        assert result == Ok(2)
+
+    async def test_early_err_does_not_end_the_race(self) -> None:
+        # the fast Err completes first, but the slow Ok still wins
+        result = await first_ok([err_after("fast", delay=0.0), ok_after(1, delay=0.05)])
+        assert result == Ok(1)
+
+    async def test_all_err_gives_input_order(self) -> None:
+        # completion order is shuffled, but the errors follow input order
+        result = await first_ok(
+            [
+                err_after("a", delay=0.05),
+                err_after("b", delay=0.0),
+                err_after("c", delay=0.02),
+            ],
+        )
+        assert result == Err(["a", "b", "c"])
+
+    async def test_winner_cancels_losers(self) -> None:
+        cancelled: list[int] = []
+
+        async def slow_ok(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            except asyncio.CancelledError:
+                cancelled.append(v)
+                raise
+
+        result = await first_ok([slow_ok(1), ok_after(0, delay=0.0), slow_ok(2)])
+        assert result == Ok(0)
+        assert sorted(cancelled) == [1, 2]
+
+    async def test_concurrency_respected(self) -> None:
+        probe = ConcurrencyProbe()
+        # all Err so the race is never won early and every item runs
+        result = await first_ok([probe.track(Err(i)) for i in range(8)], concurrency=3)
+        assert result == Err(list(range(8)))
+        assert probe.peak <= 3
+
+    async def test_early_ok_stops_consuming_source(self) -> None:
+        pulled: list[int] = []
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            for i in range(100):
+                pulled.append(i)
+                if i == 0:
+                    yield ok_after(0)
+                else:
+                    yield ok_after(i, delay=10)
+
+        result = await first_ok(source(), concurrency=3)
+        assert result == Ok(0)
+        # only the initial window of 3 was ever pulled from the source
+        assert pulled == [0, 1, 2]
+
+    async def test_async_generator_source_closed_on_early_win(self) -> None:
+        closed = False
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            nonlocal closed
+            try:
+                yield ok_after(0)
+                yield ok_after(1, delay=10)
+                yield ok_after(2, delay=10)
+            finally:
+                closed = True
+
+        result = await first_ok(source(), concurrency=2)
+        assert result == Ok(0)
+        assert closed
+
+    async def test_exception_wins_over_the_race_as_group_of_one(self) -> None:
+        # a raise is not a candidate loser: it cancels the race even though
+        # a slow alternative might still have succeeded
+        cancelled: list[int] = []
+
+        async def slow_ok(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            except asyncio.CancelledError:
+                cancelled.append(v)
+                raise
+
+        async def boom() -> Ok[int]:
+            raise ValueError("oops")
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await first_ok([slow_ok(1), boom()])
+
+        assert exc_info.group_contains(ValueError, match="oops")
+        assert len(exc_info.value.exceptions) == 1
+        assert cancelled == [1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_iterator.py
+++ b/tests/test_async_iterator.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import TypeVar
+from collections.abc import AsyncIterator, Coroutine
+from typing import Any, TypeVar
 
 import pytest
 
@@ -1134,3 +1135,275 @@ class TestTryReduce:
         result = await try_reduce([int_after(1), remaining], 0, fail)
         assert result == Err("nope: 1")
         assert inspect.getcoroutinestate(remaining) == "CORO_CLOSED"
+
+
+# ---------------------------------------------------------------------------
+# Async iterable sources
+# ---------------------------------------------------------------------------
+
+ResultCoro = Coroutine[Any, Any, Ok[int] | Err[str]]
+IntCoro = Coroutine[Any, Any, int]
+
+
+class TestAsyncIterableSources:
+    async def _slow(self, v: int, cancelled: list[int]) -> Ok[int]:
+        try:
+            await asyncio.sleep(10)
+            return Ok(v)
+        except asyncio.CancelledError:
+            cancelled.append(v)
+            raise
+
+    async def test_collect_all_ok(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            for i in range(5):
+                yield ok_after(i)
+
+        assert await collect(source()) == Ok(list(range(5)))
+
+    async def test_collect_first_err_short_circuits(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1)
+            yield err_after("bad")
+            yield ok_after(3)
+
+        assert await collect(source(), concurrency=1) == Err("bad")
+
+    async def test_collect_err_stops_consuming_source(self) -> None:
+        yielded: list[int] = []
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            for i in range(100):
+                yielded.append(i)
+                if i == 0:
+                    yield err_after("stop")
+                else:
+                    yield ok_after(i, delay=10)
+
+        result = await collect(source(), concurrency=3)
+        assert result == Err("stop")
+        # only the initial window of 3 was ever pulled from the source
+        assert yielded == [0, 1, 2]
+
+    async def test_collect_concurrency_respected(self) -> None:
+        probe = ConcurrencyProbe()
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            for i in range(8):
+                yield probe.track(Ok(i))
+
+        result = await collect(source(), concurrency=3)
+        assert result == Ok(list(range(8)))
+        assert probe.peak <= 3
+
+    async def test_collect_all_accumulates_errors(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1)
+            yield err_after("a")
+            yield err_after("b")
+
+        assert await collect_all(source()) == Err(["a", "b"])
+
+    async def test_collect_all_ok_values(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1)
+            yield ok_after(2)
+
+        assert await collect_all(source()) == Ok([1, 2])
+
+    async def test_partition_mixed(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1)
+            yield err_after("x")
+            yield ok_after(2)
+
+        assert await partition(source()) == ([1, 2], ["x"])
+
+    async def test_map_collect(self) -> None:
+        async def elements() -> AsyncIterator[int]:
+            for i in range(4):
+                yield i
+
+        async def double(x: int) -> Ok[int]:
+            await asyncio.sleep(0)
+            return Ok(x * 2)
+
+        assert await map_collect(elements(), double) == Ok([0, 2, 4, 6])
+
+    async def test_map_collect_err_short_circuits_and_closes_source(self) -> None:
+        consumed: list[int] = []
+        closed = False
+
+        async def elements() -> AsyncIterator[int]:
+            nonlocal closed
+            try:
+                for i in range(100):
+                    consumed.append(i)
+                    yield i
+            finally:
+                closed = True
+
+        async def check(x: int) -> Ok[int] | Err[str]:
+            if x == 0:
+                return Err("zero")
+            await asyncio.sleep(10)
+            return Ok(x)
+
+        result = await map_collect(elements(), check, concurrency=2)
+        assert result == Err("zero")
+        assert consumed == [0, 1]
+        assert closed
+
+    async def test_map_partition(self) -> None:
+        async def elements() -> AsyncIterator[int]:
+            for i in (1, -1, 2):
+                yield i
+
+        async def check(v: int) -> Ok[int] | Err[str]:
+            await asyncio.sleep(0)
+            return Ok(v) if v > 0 else Err(f"bad: {v}")
+
+        assert await map_partition(elements(), check) == ([1, 2], ["bad: -1"])
+
+    async def test_filter_ok_ordered(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1, delay=0.05)
+            yield err_after("x")
+            yield ok_after(2, delay=0.0)
+
+        results = [v async for v in filter_ok(source(), concurrency=3)]
+        assert results == [1, 2]
+
+    async def test_filter_err_ordered(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield err_after("slow", delay=0.05)
+            yield ok_after(1)
+            yield err_after("fast", delay=0.0)
+
+        results = [e async for e in filter_err(source(), concurrency=3)]
+        assert results == ["slow", "fast"]
+
+    async def test_filter_ok_concurrency_respected(self) -> None:
+        probe = ConcurrencyProbe()
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            for i in range(8):
+                yield probe.track(Ok(i))
+
+        async for _ in filter_ok(source(), concurrency=3):
+            pass
+        assert probe.peak <= 3
+
+    async def test_filter_ok_unordered_completion_order(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1, delay=0.05)
+            yield err_after("x")
+            yield ok_after(2, delay=0.0)
+
+        results = [v async for v in filter_ok_unordered(source())]
+        assert results == [2, 1]
+
+    async def test_filter_err_unordered_completion_order(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield err_after("slow", delay=0.05)
+            yield ok_after(1)
+            yield err_after("fast", delay=0.0)
+
+        results = [e async for e in filter_err_unordered(source())]
+        assert results == ["fast", "slow"]
+
+    async def test_filter_ok_break_closes_source_and_cancels_tasks(self) -> None:
+        cancelled: list[int] = []
+        created: list[Coroutine[Any, Any, Ok[int]]] = []
+        closed = False
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            nonlocal closed
+            i = 0
+            try:
+                yield ok_after(0)
+                while True:
+                    i += 1
+                    coro = self._slow(i, cancelled)
+                    created.append(coro)
+                    yield coro
+            finally:
+                closed = True
+
+        agen = filter_ok(source(), concurrency=2)
+        async for _ in agen:
+            break
+        await agen.aclose()
+        assert closed
+        # slow(1) was in flight and got cancelled; slow(2) was pulled during a
+        # refill but never started, so it is closed rather than cancelled
+        assert cancelled == [1]
+        assert [inspect.getcoroutinestate(c) for c in created] == ["CORO_CLOSED", "CORO_CLOSED"]
+        assert len(asyncio.all_tasks()) == 1  # only the test's own task remains
+
+    async def test_raising_source_wraps_in_group_and_cancels(self) -> None:
+        # the source raises during a refill — in-flight tasks are cancelled
+        # and the source's exception joins the group
+        cancelled: list[int] = []
+
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(0)
+            yield self._slow(1, cancelled)
+            raise RuntimeError("source broke")
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await collect(source(), concurrency=2)
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+        assert cancelled == [1]
+
+    async def test_raising_source_filter_ok_unordered(self) -> None:
+        # the source raises during the initial fill
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield ok_after(1)
+            raise RuntimeError("source broke")
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async for _ in filter_ok_unordered(source()):
+                pass
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_try_reduce(self) -> None:
+        async def source() -> AsyncIterator[IntCoro]:
+            for i in (1, 2, 3):
+                yield int_after(i)
+
+        def add(acc: int, x: int) -> Ok[int]:
+            return Ok(acc + x)
+
+        assert await try_reduce(source(), 0, add) == Ok(6)
+
+    async def test_try_reduce_short_circuit_closes_source(self) -> None:
+        closed = False
+        pulled: list[int] = []
+
+        async def source() -> AsyncIterator[IntCoro]:
+            nonlocal closed
+            try:
+                for i in (1, -1, 3):
+                    pulled.append(i)
+                    yield int_after(i)
+            finally:
+                closed = True
+
+        def maybe_fail(acc: int, x: int) -> Ok[int] | Err[str]:
+            return Err(f"negative: {x}") if x < 0 else Ok(acc + x)
+
+        assert await try_reduce(source(), 0, maybe_fail) == Err("negative: -1")
+        assert pulled == [1, -1]
+        assert closed
+
+    async def test_try_reduce_source_exception_propagates_bare(self) -> None:
+        async def source() -> AsyncIterator[IntCoro]:
+            yield int_after(1)
+            raise RuntimeError("source broke")
+
+        def add(acc: int, x: int) -> Ok[int]:
+            return Ok(acc + x)
+
+        with pytest.raises(RuntimeError, match="source broke"):
+            await try_reduce(source(), 0, add)

--- a/tests/test_async_iterator.py
+++ b/tests/test_async_iterator.py
@@ -7,7 +7,7 @@ from typing import Any, TypeVar
 
 import pytest
 
-from corrode import Err, Ok
+from corrode import Err, Ok, async_iterator
 from corrode.async_iterator import (
     collect,
     collect_all,
@@ -451,6 +451,99 @@ class TestCreateTaskInputs:
         task = asyncio.create_task(ok_after(1))
         result = await collect([ok_after(0), task, ok_after(2)])
         assert result == Ok([0, 1, 2])
+
+
+# ---------------------------------------------------------------------------
+# zip
+# ---------------------------------------------------------------------------
+
+
+async def str_after(value: str, delay: float = 0.0) -> Ok[str]:
+    await asyncio.sleep(delay)
+    return Ok(value)
+
+
+class TestZip:
+    async def test_all_ok_arity_2(self) -> None:
+        result = await async_iterator.zip(ok_after(1), str_after("a"))
+        assert result == Ok((1, "a"))
+
+    async def test_all_ok_arity_5(self) -> None:
+        result = await async_iterator.zip(
+            ok_after(1),
+            str_after("b"),
+            ok_after(3),
+            str_after("d"),
+            ok_after(5),
+        )
+        assert result == Ok((1, "b", 3, "d", 5))
+
+    async def test_argument_order_regardless_of_completion_order(self) -> None:
+        # the second awaitable completes first, but the tuple follows argument order
+        result = await async_iterator.zip(
+            ok_after(1, delay=0.1),
+            str_after("a", delay=0.0),
+            ok_after(3, delay=0.05),
+        )
+        assert result == Ok((1, "a", 3))
+
+    async def test_first_completing_err_wins(self) -> None:
+        result = await async_iterator.zip(
+            err_after("slow", delay=0.1),
+            err_after("fast", delay=0.0),
+        )
+        assert result == Err("fast")
+
+    async def test_err_cancels_remaining(self) -> None:
+        cancelled: list[int] = []
+
+        async def slow_ok(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            except asyncio.CancelledError:
+                cancelled.append(v)
+                raise
+
+        result = await async_iterator.zip(
+            slow_ok(1),
+            err_after("boom", delay=0.0),
+            slow_ok(2),
+        )
+        assert result == Err("boom")
+        assert sorted(cancelled) == [1, 2]
+
+    async def test_exception_raises_group_and_cancels_rest(self) -> None:
+        cancelled: list[int] = []
+
+        async def slow(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            except asyncio.CancelledError:
+                cancelled.append(v)
+                raise
+
+        async def boom() -> Ok[int]:
+            raise ValueError("oops")
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await async_iterator.zip(slow(1), boom())
+
+        assert exc_info.group_contains(ValueError, match="oops")
+        assert len(exc_info.value.exceptions) == 1
+        assert cancelled == [1]
+
+    async def test_works_with_tasks(self) -> None:
+        task_a = asyncio.create_task(ok_after(1))
+        task_b = asyncio.create_task(str_after("a"))
+        result = await async_iterator.zip(task_a, task_b)
+        assert result == Ok((1, "a"))
+
+    async def test_mixed_coros_and_tasks(self) -> None:
+        task = asyncio.create_task(str_after("a"))
+        result = await async_iterator.zip(ok_after(1), task, ok_after(3))
+        assert result == Ok((1, "a", 3))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_async_iterator.py
+++ b/tests/test_async_iterator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from collections.abc import AsyncIterator, Coroutine
+from collections.abc import AsyncIterator, Coroutine, Iterator
 from typing import Any, TypeVar
 
 import pytest
@@ -1656,6 +1656,13 @@ class TestAsyncIterableSources:
                 pass
         assert exc_info.group_contains(RuntimeError, match="source broke")
 
+    async def test_first_ok_err_refills_from_async_source(self) -> None:
+        async def source() -> AsyncIterator[ResultCoro]:
+            yield err_after("e0")
+            yield ok_after(7)
+
+        assert await first_ok(source(), concurrency=1) == Ok(7)
+
     async def test_try_reduce(self) -> None:
         async def source() -> AsyncIterator[IntCoro]:
             for i in (1, 2, 3):
@@ -1696,3 +1703,85 @@ class TestAsyncIterableSources:
 
         with pytest.raises(RuntimeError, match="source broke"):
             await try_reduce(source(), 0, add)
+
+
+# ---------------------------------------------------------------------------
+# Raising sync sources
+# ---------------------------------------------------------------------------
+
+
+class TestRaisingSyncSources:
+    """A raising sync source follows the same contract as a raising async one."""
+
+    def _source(self, first: ResultCoro) -> Iterator[ResultCoro]:
+        yield first
+        raise RuntimeError("source broke")
+
+    async def test_collect_initial_fill_wraps_in_group(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await collect(self._source(ok_after(1)))
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_collect_refill_wraps_in_group_and_cancels(self) -> None:
+        cancelled: list[int] = []
+
+        async def slow(v: int) -> Ok[int]:
+            try:
+                await asyncio.sleep(10)
+                return Ok(v)
+            except asyncio.CancelledError:
+                cancelled.append(v)
+                raise
+
+        def source() -> Iterator[ResultCoro]:
+            yield ok_after(0)
+            yield slow(1)
+            raise RuntimeError("source broke")
+
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await collect(source(), concurrency=2)
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+        assert cancelled == [1]
+
+    async def test_partition_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await partition(self._source(ok_after(0)), concurrency=1)
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_first_ok_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            await first_ok(self._source(err_after("e")), concurrency=1)
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_filter_ok_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async for _ in filter_ok(self._source(ok_after(1)), concurrency=1):
+                pass
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_filter_err_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async for _ in filter_err(self._source(err_after("e")), concurrency=1):
+                pass
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_filter_ok_unordered_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async for _ in filter_ok_unordered(self._source(ok_after(1)), concurrency=1):
+                pass
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_filter_err_unordered_refill(self) -> None:
+        with pytest.raises(BaseExceptionGroup) as exc_info:
+            async for _ in filter_err_unordered(self._source(err_after("e")), concurrency=1):
+                pass
+        assert exc_info.group_contains(RuntimeError, match="source broke")
+
+    async def test_cancellation_passes_through_bare(self) -> None:
+        # cancellation is not a source failure — it must not be wrapped
+        def source() -> Iterator[ResultCoro]:
+            yield ok_after(0)
+            raise asyncio.CancelledError
+
+        with pytest.raises(asyncio.CancelledError):
+            await collect(source(), concurrency=1)

--- a/tests/test_iterator.py
+++ b/tests/test_iterator.py
@@ -6,6 +6,7 @@ from corrode.iterator import (
     collect_all,
     filter_err,
     filter_ok,
+    first_ok,
     map_collect,
     map_partition,
     partition,
@@ -116,6 +117,41 @@ class TestCollectAll:
     def test_ok_values_dropped_on_error(self) -> None:
         # all-or-nothing: Ok values are not observable when any Err is present
         assert collect_all([Ok(1), Err("a")]) == Err(["a"])
+
+
+# ---------------------------------------------------------------------------
+# first_ok
+# ---------------------------------------------------------------------------
+
+
+class TestFirstOk:
+    def test_first_ok_wins(self) -> None:
+        assert first_ok([Ok(1), Ok(2), Ok(3)]) == Ok(1)
+
+    def test_short_circuits_on_first_ok(self) -> None:
+        produced = 0
+
+        def counted_iter():
+            nonlocal produced
+            for r in [Err("a"), Ok(2), Ok(3)]:
+                produced += 1
+                yield r
+
+        result = first_ok(counted_iter())
+        assert result == Ok(2)
+        assert produced == 2  # stopped after the Ok
+
+    def test_earlier_errs_skipped(self) -> None:
+        assert first_ok([Err("a"), Err("b"), Ok(3), Err("c")]) == Ok(3)
+
+    def test_all_err_gives_input_order(self) -> None:
+        assert first_ok([Err("a"), Err("b"), Err("c")]) == Err(["a", "b", "c"])
+
+    def test_empty(self) -> None:
+        assert first_ok([]) == Err([])
+
+    def test_generator_input(self) -> None:
+        assert first_ok(Err(str(x)) for x in range(3)) == Err(["0", "1", "2"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -827,6 +827,26 @@ class TestFlatten:
 
 
 # ---------------------------------------------------------------------------
+# transpose
+# ---------------------------------------------------------------------------
+
+
+class TestTranspose:
+    def test_ok_of_none(self) -> None:
+        assert Ok(None).transpose() is None
+
+    def test_ok_of_value(self) -> None:
+        assert Ok(1).transpose() == Ok(1)
+
+    def test_err(self) -> None:
+        assert Err("bad").transpose() == Err("bad")
+
+    def test_ok_of_value_preserves_equality(self) -> None:
+        ok: Ok[int | None] = Ok(42)
+        assert ok.transpose() == ok
+
+
+# ---------------------------------------------------------------------------
 # from_optional / from_optional_or_else
 # ---------------------------------------------------------------------------
 

--- a/tests/type_checking/typesafety.py
+++ b/tests/type_checking/typesafety.py
@@ -6,7 +6,8 @@ statically to ensure the corrode public API is correctly typed.
 
 from __future__ import annotations
 
-from collections.abc import Awaitable
+from collections.abc import AsyncIterator, Awaitable, Coroutine
+from typing import Any
 
 from corrode import (
     DoError,
@@ -361,3 +362,20 @@ async def _async_iter_examples() -> None:
         fetch,
         concurrency=2,
     )
+
+
+# ---------------------------------------------------------------------------
+# 21. async_iterator: async iterable sources
+# ---------------------------------------------------------------------------
+
+
+async def _async_source_examples() -> None:
+    async def fetch(i: int) -> Result[int, str]:
+        return Ok(i)
+
+    async def source() -> AsyncIterator[Coroutine[Any, Any, Result[int, str]]]:
+        yield fetch(1)
+        yield fetch(2)
+
+    _acollected: Result[list[int], str] = await async_iterator.collect(source(), concurrency=2)
+    _afiltered: list[int] = [v async for v in async_iterator.filter_ok(source(), concurrency=2)]

--- a/tests/type_checking/typesafety.py
+++ b/tests/type_checking/typesafety.py
@@ -379,3 +379,40 @@ async def _async_source_examples() -> None:
 
     _acollected: Result[list[int], str] = await async_iterator.collect(source(), concurrency=2)
     _afiltered: list[int] = [v async for v in async_iterator.filter_ok(source(), concurrency=2)]
+
+
+# ---------------------------------------------------------------------------
+# 22. async_iterator: zip
+# ---------------------------------------------------------------------------
+
+
+async def _async_zip_examples() -> None:
+    async def fetch_int() -> Result[int, str]:
+        return Ok(1)
+
+    async def fetch_str() -> Result[str, str]:
+        return Ok("a")
+
+    async def fetch_float() -> Result[float, ValueError]:
+        return Ok(3.0)
+
+    # heterogeneous value types infer the right tuple
+    _az2: Result[tuple[int, str], str] = await async_iterator.zip(fetch_int(), fetch_str())
+    _az5: Result[tuple[int, str, int, str, int], str] = await async_iterator.zip(
+        fetch_int(),
+        fetch_str(),
+        fetch_int(),
+        fetch_str(),
+        fetch_int(),
+    )
+
+    # heterogeneous error types produce a usable union
+    _az_mixed_err: Result[tuple[int, float], str | ValueError] = await async_iterator.zip(
+        fetch_int(),
+        fetch_float(),
+    )
+    match _az_mixed_err:
+        case Ok(pair):
+            _az_values: tuple[int, float] = pair
+        case Err(error):
+            _az_error: str | ValueError = error

--- a/tests/type_checking/typesafety.py
+++ b/tests/type_checking/typesafety.py
@@ -416,3 +416,25 @@ async def _async_zip_examples() -> None:
             _az_values: tuple[int, float] = pair
         case Err(error):
             _az_error: str | ValueError = error
+
+
+# ---------------------------------------------------------------------------
+# 23. iterator / async_iterator: first_ok
+# ---------------------------------------------------------------------------
+
+_first_ok_sync: Result[int, list[str]] = iterator.first_ok([make_ok(), make_err()])
+
+
+async def _first_ok_examples() -> None:
+    async def fetch(i: int) -> Result[int, str]:
+        return Ok(i)
+
+    # plain iterable of awaitables
+    _afo: Result[int, list[str]] = await async_iterator.first_ok([fetch(1), fetch(2)])
+
+    # async-generator source
+    async def source() -> AsyncIterator[Coroutine[Any, Any, Result[int, str]]]:
+        yield fetch(1)
+        yield fetch(2)
+
+    _afo_src: Result[int, list[str]] = await async_iterator.first_ok(source(), concurrency=2)

--- a/tests/type_checking/typesafety.py
+++ b/tests/type_checking/typesafety.py
@@ -294,7 +294,7 @@ _iter_mod = iterator
 _async_iter_mod = async_iterator
 
 # ---------------------------------------------------------------------------
-# 16. flatten
+# 16. flatten / transpose
 # ---------------------------------------------------------------------------
 
 
@@ -304,6 +304,14 @@ def make_nested() -> Result[Result[int, str], str]:
 
 _flattened: Result[int, str] = make_nested().flatten()
 _flatten_err: Err[str] = Err("bad").flatten()
+
+
+def make_optional_result() -> Result[int | None, str]:
+    return Ok(1)
+
+
+_transposed: Result[int, str] | None = make_optional_result().transpose()
+_transpose_err: Err[str] = Err("bad").transpose()
 
 # ---------------------------------------------------------------------------
 # 17. from_optional / from_optional_or_else


### PR DESCRIPTION
Four additions to the API, plus the documentation that says why each one exists.

## API

| Addition | Semantics |
| --- | --- |
| `Result.transpose` | `Result[T \| None, E]` → `Result[T, E] \| None`; the inverse of `from_optional` |
| `async_iterator.zip` | 2–5 awaitables of different `Ok` types → `Ok[tuple]`, or the first `Err`, cancelling the rest |
| `iterator.first_ok` / `async_iterator.first_ok` | the dual of `collect`: the first value, or all errors. The async form races the alternatives; an early `Err` does not end the race |
| async sources (**breaking**) | every `async_iterator` function takes `Iterable[...] \| AsyncIterable[...]`, consumed lazily and closed on every exit path |

**BREAKING CHANGE**: an exception raised by a *sync* source iterable during iteration now propagates wrapped in an `ExceptionGroup`, matching the module's uniform exception contract, instead of bare. Sequential `try_reduce` keeps bare propagation.

Also in the branch: a fix for a pre-existing leak (a wrapper task cancelled before its first step left the wrapped coroutine to GC), hardened teardown (a source-teardown exception can no longer mask `try_reduce`'s outcome or abort the drain), `ValueError` on `concurrency < 1` instead of silently scheduling nothing, and an internals refactor that keeps the non-awaiting fast path for sync sources.

## Documentation

The last commit adds the "why would I reach for this" half:

- **Racing alternatives** — hedged download across CDN mirrors. Shows the two things that distinguish `first_ok` from `asyncio.wait(FIRST_COMPLETED)`: a mirror answering `404` in a millisecond must not beat the mirror that has the file, and a total failure reports every mirror instead of one opaque "download failed".
- **Fan-out over different types** — a checkout page built from profile + balance + shipping quote. The heterogeneous case `collect` cannot cover; the cancellation of the slow upstream is asserted, not just claimed.
- **Streaming sources** — a paginated orders API consumed through an async generator, so listing and fetching interleave and at most `concurrency` requests are in flight.
- Sync `first_ok` as a webhook schema-version fallback, and `transpose` in the Tour keeping "this order has no coupon" apart from "the coupon service is down".

Docstrings for `first_ok`, `zip`, `transpose` and `collect` now state the use case, with synthetic examples (`fetch_name`/`fetch_age`) replaced by domain ones.

## Verification

`just lint test` clean: ruff, `mypy` (3.11 + default), `basedpyright`, `ty`, `pyrefly`, and 473 tests — which include every README block executed and type-checked under `mypy --strict`, plus the doctests. `mkdocs build --strict` builds.
